### PR TITLE
Fix dist_dir path to correctly serve UI

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -73,7 +73,7 @@ def create_app(config_name=None):
     if bundle_dir:
         dist_dir = os.path.join(bundle_dir, 'frontend', 'dist', 'gaps-2')
     else:
-        dist_dir = os.path.join(os.path.dirname(os.path.dirname(__file__)), '..', 'frontend', 'dist', 'gaps-2')
+        dist_dir = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'frontend', 'dist', 'gaps-2')
     if os.path.isdir(dist_dir):
         @app.route('/', defaults={'path': ''})
         @app.route('/<path:path>')


### PR DESCRIPTION
This pull request makes a minor update to the way the `dist_dir` path is constructed in the `create_app` function. The change removes an unnecessary `'..'` from the path, ensuring the application correctly locates the frontend distribution directory.