### PR TITLE
Remove budget references from the project

### DIFF
--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -39,18 +39,7 @@
           },
           "configurations": {
             "production": {
-              "budgets": [
-                {
-                  "type": "initial",
-                  "maximumWarning": "700kb",
-                  "maximumError": "1mb"
-                },
-                {
-                  "type": "anyComponentStyle",
-                  "maximumWarning": "4kb",
-                  "maximumError": "8kb"
-                }
-              ],
+              "budgets": [],
               "fileReplacements": [
                 {
                   "replace": "src/environments/environment.ts",


### PR DESCRIPTION
This pull request makes a minor change to the Angular build configuration for production. The change removes all budget constraints, which previously enforced limits on bundle and component style sizes.

* Removed all budget constraints from the production configuration in `angular.json`, allowing builds to proceed without warnings or errors related to bundle or style size limits.Remove the budget