### PR TITLE
Add gosu entrypoint for non-root user configuration

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,6 +10,22 @@ RUN npm run build
 FROM python:3.11-slim
 WORKDIR /app
 
+# Create app user/group
+RUN addgroup --gid 1000 appgroup && \
+    adduser --uid 1000 --ingroup appgroup --gecos "" --no-create-home --shell /bin/false appuser
+
+# Install gosu to drop privileges
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ca-certificates gnupg wget && \
+    wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/1.16/gosu-$(dpkg --print-architecture)" && \
+    chmod +x /usr/local/bin/gosu && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+ENV PUID=1000
+ENV PGID=1000
+
+
 COPY backend/requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt gunicorn
 
@@ -22,5 +38,11 @@ COPY --from=frontend-build /app/frontend/dist/gaps-2 /app/frontend/dist/gaps-2
 RUN mkdir -p /app/data
 
 EXPOSE 5000
+
+# Copy entrypoint
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]
 
 CMD ["gunicorn", "--bind", "0.0.0.0:5000", "--workers", "1", "--threads", "4", "run:app"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -e
+
+# Set defaults if not provided
+PUID=${PUID:-1000}
+PGID=${PGID:-1000}
+
+# Adjust UID/GID of the internal app user
+groupmod -o -g "${PGID}" appgroup
+usermod -o -u "${PUID}" appuser
+
+# Ensure app data dir is owned by appuser:appgroup
+chown -R appuser:appgroup /app
+
+# Exec gunicorn as the appuser via su-exec
+exec gosu appuser:appgroup "$@"


### PR DESCRIPTION
Added gosu and a small entrypoint script to change running user to non-root. Configureable via standard PUID/PGID environment variables.