### PR TITLE
Add configurable media server timeout and TMDB linking features

### DIFF
--- a/backend/app/blueprints/preferences.py
+++ b/backend/app/blueprints/preferences.py
@@ -12,6 +12,7 @@ DEFAULTS = {
     'autoOpenBrowser': True,
     'posterPrefetch': False,
     'imageCacheEnabled': False,
+    'mediaServerTimeout': 30,
 }
 
 

--- a/backend/app/blueprints/recommendations.py
+++ b/backend/app/blueprints/recommendations.py
@@ -4,14 +4,19 @@ from app.services import config_store
 recommendations_bp = Blueprint('recommendations', __name__)
 
 
+def _get_service(source: str):
+    """Get the appropriate media server service."""
+    if source == 'jellyfin':
+        return current_app.jellyfin_service
+    elif source == 'emby':
+        return current_app.emby_service
+    else:
+        return current_app.plex_service
+
+
 def _get_movies_cache(source: str) -> dict:
     """Get the movies cache from the appropriate media server service."""
-    if source == 'jellyfin':
-        return current_app.jellyfin_service.movies_cache
-    elif source == 'emby':
-        return current_app.emby_service.movies_cache
-    else:
-        return current_app.plex_service.movies_cache
+    return _get_service(source).movies_cache
 
 
 @recommendations_bp.route('/movie', methods=['GET'])
@@ -81,7 +86,17 @@ def scan_library_gaps():
     if tmdb.scan_progress.get('status') == 'scanning':
         return jsonify(error='A scan is already in progress'), 409
 
-    cache = _get_movies_cache(source)
+    service = _get_service(source)
+
+    if fresh_scan:
+        tmdb.clear_cache()
+        # Clear cached movie lists so we re-fetch from the media server
+        service._movies_cache = {}
+        # Re-fetch movies for the selected libraries
+        for name in names:
+            service.get_movies(name)
+
+    cache = service.movies_cache
 
     # Merge movies and IDs from all selected libraries
     owned_movies = []
@@ -99,9 +114,6 @@ def scan_library_gaps():
 
     if not owned_movies:
         return jsonify(error='No movies loaded for the selected libraries. Browse the libraries first to load movie data.'), 400
-
-    if fresh_scan:
-        tmdb.clear_cache()
 
     tmdb.start_scan(
         api_key=api_key,

--- a/backend/app/services/emby_service.py
+++ b/backend/app/services/emby_service.py
@@ -195,7 +195,9 @@ class EmbyService:
             else:
                 url = f"{self._base()}/Items"
 
-            resp = requests.get(url, headers=self._headers(), params=params, timeout=30)
+            prefs = config_store.get('preferences', {})
+            timeout = prefs.get('mediaServerTimeout', 30)
+            resp = requests.get(url, headers=self._headers(), params=params, timeout=timeout)
             if resp.status_code != 200:
                 return None, f'Failed to fetch movies (HTTP {resp.status_code})'
 

--- a/backend/app/services/jellyfin_service.py
+++ b/backend/app/services/jellyfin_service.py
@@ -195,7 +195,9 @@ class JellyfinService:
             else:
                 url = f"{self._base()}/Items"
 
-            resp = requests.get(url, headers=self._headers(), params=params, timeout=30)
+            prefs = config_store.get('preferences', {})
+            timeout = prefs.get('mediaServerTimeout', 30)
+            resp = requests.get(url, headers=self._headers(), params=params, timeout=timeout)
             if resp.status_code != 200:
                 return None, f'Failed to fetch movies (HTTP {resp.status_code})'
 

--- a/backend/app/services/plex_service.py
+++ b/backend/app/services/plex_service.py
@@ -40,10 +40,14 @@ class PlexService:
 
     # -- Manual connection --
 
+    def _timeout(self) -> int:
+        prefs = config_store.get('preferences', {})
+        return prefs.get('mediaServerTimeout', 30)
+
     def connect_manual(self, server_url: str, token: str) -> tuple[bool, str | None, list | None, str | None]:
         """Connect directly to a Plex server using URL and token."""
         try:
-            server = PlexServer(server_url, token, timeout=5)
+            server = PlexServer(server_url, token, timeout=self._timeout())
             self._server_conn = server
             self._server_conn_name = server.friendlyName
             self._token = token
@@ -102,7 +106,7 @@ class PlexService:
         if self._active_server and self._active_server.get('serverUrl'):
             token = self._active_server.get('token', self._token)
             try:
-                server = PlexServer(self._active_server['serverUrl'], token, timeout=5)
+                server = PlexServer(self._active_server['serverUrl'], token, timeout=self._timeout())
                 self._server_conn = server
                 self._server_conn_name = server_name
                 return server
@@ -113,7 +117,7 @@ class PlexService:
         if self._token:
             try:
                 account = MyPlexAccount(token=self._token)
-                server = account.resource(server_name).connect(timeout=10)
+                server = account.resource(server_name).connect(timeout=self._timeout())
                 self._server_conn = server
                 self._server_conn_name = server_name
                 logger.info("Connected to Plex server '%s' via MyPlexAccount", server_name)

--- a/frontend/src/app/app.component.spec.ts
+++ b/frontend/src/app/app.component.spec.ts
@@ -1,29 +1,34 @@
 import { TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
 import { AppComponent } from './app.component';
+import { Component } from '@angular/core';
+import { RouterTestingModule } from '@angular/router/testing';
+
+@Component({ selector: 'app-header', template: '', standalone: false })
+class MockHeaderComponent {}
 
 describe('AppComponent', () => {
-  beforeEach(() => TestBed.configureTestingModule({
-    imports: [RouterTestingModule],
-    declarations: [AppComponent]
-  }));
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [RouterTestingModule],
+      declarations: [AppComponent, MockHeaderComponent],
+    }).compileComponents();
+  });
 
   it('should create the app', () => {
     const fixture = TestBed.createComponent(AppComponent);
-    const app = fixture.componentInstance;
-    expect(app).toBeTruthy();
+    expect(fixture.componentInstance).toBeTruthy();
   });
 
-  it(`should have as title 'GAPS-2'`, () => {
+  it('should have title GAPS-2', () => {
     const fixture = TestBed.createComponent(AppComponent);
-    const app = fixture.componentInstance;
-    expect(app.title).toEqual('GAPS-2');
+    expect(fixture.componentInstance.title).toEqual('GAPS-2');
   });
 
-  it('should render title', () => {
+  it('should render app-header and router-outlet', () => {
     const fixture = TestBed.createComponent(AppComponent);
     fixture.detectChanges();
-    const compiled = fixture.nativeElement as HTMLElement;
-    expect(compiled.querySelector('.content span')?.textContent).toContain('GAPS-2 app is running!');
+    const el = fixture.nativeElement as HTMLElement;
+    expect(el.querySelector('app-header')).toBeTruthy();
+    expect(el.querySelector('router-outlet')).toBeTruthy();
   });
 });

--- a/frontend/src/app/components/about/about.component.spec.ts
+++ b/frontend/src/app/components/about/about.component.spec.ts
@@ -1,21 +1,73 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
-
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { AboutComponent } from './about.component';
+import { environment } from '../../../environments/environment';
 
 describe('AboutComponent', () => {
   let component: AboutComponent;
   let fixture: ComponentFixture<AboutComponent>;
+  let httpMock: HttpTestingController;
 
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      declarations: [AboutComponent]
-    });
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      declarations: [AboutComponent],
+    }).compileComponents();
+
     fixture = TestBed.createComponent(AboutComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  it('should set version from environment', () => {
+    expect(component.version).toEqual(environment.version);
+  });
+
+  it('should start in loading state', () => {
+    expect(component.releasesLoading).toBeTrue();
+    expect(component.releases).toEqual([]);
+  });
+
+  it('should load and parse releases from GitHub API on init', fakeAsync(() => {
+    fixture.detectChanges();
+
+    const req = httpMock.expectOne('https://api.github.com/repos/primetime43/GAPS-2/releases');
+    expect(req.request.method).toBe('GET');
+
+    req.flush([
+      {
+        tag_name: 'v2.1.0',
+        name: 'Release 2.1.0',
+        body: '**New features**',
+        published_at: '2025-01-01T00:00:00Z',
+        html_url: 'https://github.com/primetime43/GAPS-2/releases/tag/v2.1.0',
+      }
+    ]);
+    tick();
+
+    expect(component.releasesLoading).toBeFalse();
+    expect(component.releases.length).toBe(1);
+    expect(component.releases[0].tag_name).toBe('v2.1.0');
+    expect(component.releases[0].bodyHtml).toBeTruthy();
+  }));
+
+  it('should handle GitHub API error gracefully', fakeAsync(() => {
+    fixture.detectChanges();
+
+    const req = httpMock.expectOne('https://api.github.com/repos/primetime43/GAPS-2/releases');
+    req.error(new ProgressEvent('Network error'));
+    tick();
+
+    expect(component.releasesLoading).toBeFalse();
+    expect(component.releasesError).toBe('Could not load releases from GitHub.');
+    expect(component.releases).toEqual([]);
+  }));
 });

--- a/frontend/src/app/components/header/header.component.spec.ts
+++ b/frontend/src/app/components/header/header.component.spec.ts
@@ -1,15 +1,17 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
+import { RouterTestingModule } from '@angular/router/testing';
 import { HeaderComponent } from './header.component';
 
 describe('HeaderComponent', () => {
   let component: HeaderComponent;
   let fixture: ComponentFixture<HeaderComponent>;
 
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      declarations: [HeaderComponent]
-    });
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [RouterTestingModule],
+      declarations: [HeaderComponent],
+    }).compileComponents();
+
     fixture = TestBed.createComponent(HeaderComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
@@ -17,5 +19,25 @@ describe('HeaderComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should render navigation links for Dashboard, Missing, Settings, Logs, and About', () => {
+    const el = fixture.nativeElement as HTMLElement;
+    const linkTexts = Array.from(el.querySelectorAll('a.nav-link'))
+      .map(a => a.textContent?.trim());
+
+    expect(linkTexts.some(t => t?.includes('Dashboard'))).toBeTrue();
+    expect(linkTexts.some(t => t?.includes('Missing'))).toBeTrue();
+    expect(linkTexts.some(t => t?.includes('Settings'))).toBeTrue();
+    expect(linkTexts.some(t => t?.includes('Logs'))).toBeTrue();
+    expect(linkTexts.some(t => t?.includes('About'))).toBeTrue();
+  });
+
+  it('should render the logo image linking to home', () => {
+    const el = fixture.nativeElement as HTMLElement;
+    const logoLink = el.querySelector('a[ng-reflect-router-link="/"]');
+    const logoImg = el.querySelector('img[src*="final-gaps"]');
+    expect(logoLink).toBeTruthy();
+    expect(logoImg).toBeTruthy();
   });
 });

--- a/frontend/src/app/components/recommended/recommended.component.html
+++ b/frontend/src/app/components/recommended/recommended.component.html
@@ -281,16 +281,31 @@
               (click)="toggleIgnore(gap, $event)">
               {{ isIgnored(gap) ? '&#10003;' : '&#10005;' }}
             </button>
-            <img
-              *ngIf="gap.posterUrl"
-              [src]="gap.posterUrl"
-              [alt]="gap.name"
-              class="rec-poster"
-              loading="lazy"
-            >
-            <div *ngIf="!gap.posterUrl" class="rec-poster-placeholder">No Image</div>
+            <a *ngIf="gap.tmdbId" [href]="'https://www.themoviedb.org/movie/' + gap.tmdbId" target="_blank" rel="noopener noreferrer">
+              <img
+                *ngIf="gap.posterUrl"
+                [src]="gap.posterUrl"
+                [alt]="gap.name"
+                class="rec-poster"
+                loading="lazy"
+              >
+              <div *ngIf="!gap.posterUrl" class="rec-poster-placeholder">No Image</div>
+            </a>
+            <ng-container *ngIf="!gap.tmdbId">
+              <img
+                *ngIf="gap.posterUrl"
+                [src]="gap.posterUrl"
+                [alt]="gap.name"
+                class="rec-poster"
+                loading="lazy"
+              >
+              <div *ngIf="!gap.posterUrl" class="rec-poster-placeholder">No Image</div>
+            </ng-container>
             <div class="rec-info">
-              <div class="rec-title">{{ gap.name }}</div>
+              <a *ngIf="gap.tmdbId" [href]="'https://www.themoviedb.org/movie/' + gap.tmdbId" target="_blank" rel="noopener noreferrer" class="rec-title-link">
+                {{ gap.name }}
+              </a>
+              <div *ngIf="!gap.tmdbId" class="rec-title">{{ gap.name }}</div>
               <div class="rec-year">{{ gap.year }}</div>
             </div>
           </div>

--- a/frontend/src/app/components/recommended/recommended.component.scss
+++ b/frontend/src/app/components/recommended/recommended.component.scss
@@ -209,13 +209,23 @@
   padding: 10px;
 }
 
-.rec-title {
+.rec-title,
+.rec-title-link {
   color: #fff;
   font-size: 14px;
   font-weight: 500;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  display: block;
+}
+
+.rec-title-link {
+  text-decoration: none;
+
+  &:hover {
+    color: #00bc8c;
+  }
 }
 
 .rec-year {

--- a/frontend/src/app/components/recommended/recommended.component.spec.ts
+++ b/frontend/src/app/components/recommended/recommended.component.spec.ts
@@ -1,21 +1,329 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
-
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { FormsModule } from '@angular/forms';
+import { Component, Input, Output, EventEmitter } from '@angular/core';
+import { of, throwError } from 'rxjs';
 import { RecommendedComponent } from './recommended.component';
+import { PlexService } from '../../services/plex.service';
+import { JellyfinService } from '../../services/jellyfin.service';
+import { EmbyService } from '../../services/emby.service';
+import { LibraryService } from '../../services/library.service';
+import { RecommendationService } from '../../services/recommendation.service';
+import { PreferencesService } from '../../services/preferences.service';
+import { ExportService } from '../../services/export.service';
+import { CollectionGap } from '../../models/recommendation.model';
+
+@Component({ selector: 'app-confirm-modal', template: '', standalone: false })
+class MockConfirmModalComponent {
+  @Input() visible = false;
+  @Input() title = '';
+  @Input() message = '';
+  @Input() confirmText = '';
+  @Input() cancelText = '';
+  @Input() type = 'warning';
+  @Output() confirmed = new EventEmitter<void>();
+  @Output() cancelled = new EventEmitter<void>();
+}
 
 describe('RecommendedComponent', () => {
   let component: RecommendedComponent;
   let fixture: ComponentFixture<RecommendedComponent>;
 
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      declarations: [RecommendedComponent]
-    });
+  let plexService: jasmine.SpyObj<PlexService>;
+  let jellyfinService: jasmine.SpyObj<JellyfinService>;
+  let embyService: jasmine.SpyObj<EmbyService>;
+  let libraryService: jasmine.SpyObj<LibraryService>;
+  let recommendationService: jasmine.SpyObj<RecommendationService>;
+  let preferencesService: jasmine.SpyObj<PreferencesService>;
+  let exportService: jasmine.SpyObj<ExportService>;
+
+  beforeEach(async () => {
+    plexService = jasmine.createSpyObj('PlexService', ['getActiveServer']);
+    jellyfinService = jasmine.createSpyObj('JellyfinService', ['getActiveServer']);
+    embyService = jasmine.createSpyObj('EmbyService', ['getActiveServer']);
+    libraryService = jasmine.createSpyObj('LibraryService', ['getMovies']);
+    recommendationService = jasmine.createSpyObj('RecommendationService', [
+      'getGapsForMovie', 'startScan', 'getScanProgress', 'getIgnored',
+      'addIgnored', 'removeIgnored', 'addIgnoredBulk', 'removeIgnoredBulk',
+    ]);
+    preferencesService = jasmine.createSpyObj('PreferencesService', ['load', 'save']);
+    exportService = jasmine.createSpyObj('ExportService', ['exportGaps']);
+
+    // Default mock returns
+    plexService.getActiveServer.and.returnValue(of({} as any));
+    jellyfinService.getActiveServer.and.returnValue(of({} as any));
+    embyService.getActiveServer.and.returnValue(of({} as any));
+    recommendationService.getIgnored.and.returnValue(of([]));
+    preferencesService.load.and.returnValue(of({
+      defaultLibrary: '',
+      moviesPerPage: 50,
+      hideOwnedByDefault: false,
+      language: 'en',
+      port: 5000,
+      autoOpenBrowser: true,
+      posterPrefetch: false,
+      imageCacheEnabled: false,
+      mediaServerTimeout: 30,
+    }));
+
+    await TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule, FormsModule],
+      declarations: [RecommendedComponent, MockConfirmModalComponent],
+      providers: [
+        { provide: PlexService, useValue: plexService },
+        { provide: JellyfinService, useValue: jellyfinService },
+        { provide: EmbyService, useValue: embyService },
+        { provide: LibraryService, useValue: libraryService },
+        { provide: RecommendationService, useValue: recommendationService },
+        { provide: PreferencesService, useValue: preferencesService },
+        { provide: ExportService, useValue: exportService },
+      ],
+    }).compileComponents();
+
     fixture = TestBed.createComponent(RecommendedComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should detect Plex as active source and load movie libraries', fakeAsync(() => {
+    plexService.getActiveServer.and.returnValue(of({
+      server: 'My Plex',
+      token: 'tok',
+      libraries: [
+        { title: 'Movies', type: 'movie' },
+        { title: 'TV', type: 'show' },
+      ],
+    }));
+
+    fixture.detectChanges();
+    tick();
+
+    expect(component.hasServer).toBeTrue();
+    expect(component.activeSource).toBe('plex');
+    expect(component.activeServerName).toBe('My Plex');
+    expect(component.libraries.length).toBe(1);
+    expect(component.libraries[0].title).toBe('Movies');
+    expect(component.loading).toBeFalse();
+  }));
+
+  it('should detect Emby when Plex is not connected', fakeAsync(() => {
+    embyService.getActiveServer.and.returnValue(of({
+      server: 'My Emby',
+      token: '',
+      libraries: [{ title: 'Films', type: 'movie' }],
+    }));
+
+    fixture.detectChanges();
+    tick();
+
+    expect(component.activeSource).toBe('emby');
+    expect(component.activeServerName).toBe('My Emby');
+  }));
+
+  it('should auto-select default library from preferences', fakeAsync(() => {
+    preferencesService.load.and.returnValue(of({
+      defaultLibrary: 'Movies',
+      moviesPerPage: 25,
+      hideOwnedByDefault: true,
+      language: 'en',
+      port: 5000,
+      autoOpenBrowser: true,
+      posterPrefetch: false,
+      imageCacheEnabled: false,
+      mediaServerTimeout: 30,
+    }));
+    plexService.getActiveServer.and.returnValue(of({
+      server: 'Plex',
+      token: 'tok',
+      libraries: [{ title: 'Movies', type: 'movie' }],
+    }));
+    libraryService.getMovies.and.returnValue(of({ movies: [] }));
+
+    fixture.detectChanges();
+    tick();
+
+    expect(component.selectedLibrary).toBe('Movies');
+    expect(component.moviesPerPage).toBe(25);
+    expect(component.showOwned).toBeFalse(); // hideOwnedByDefault = true
+  }));
+
+  it('should load movies when a library is selected', fakeAsync(() => {
+    plexService.getActiveServer.and.returnValue(of({
+      server: 'Plex', token: 'tok',
+      libraries: [{ title: 'Movies', type: 'movie' }],
+    }));
+    fixture.detectChanges();
+    tick();
+
+    const mockMovies = [
+      { name: 'Alien', year: 1979, overview: '', posterUrl: '', tmdbId: 348 },
+      { name: 'Aliens', year: 1986, overview: '', posterUrl: '', tmdbId: 679 },
+    ];
+    libraryService.getMovies.and.returnValue(of({ movies: mockMovies } as any));
+
+    component.selectedLibrary = 'Movies';
+    component.selectedLibraries = ['Movies'];
+    component.onLibrarySelect();
+    tick();
+
+    expect(component.movies.length).toBe(2);
+    expect(component.loadingMovies).toBeFalse();
+  }));
+
+  it('filteredMovies should filter by movieFilter text', fakeAsync(() => {
+    component.movies = [
+      { name: 'Alien', year: 1979, overview: '', posterUrl: '' },
+      { name: 'The Matrix', year: 1999, overview: '', posterUrl: '' },
+    ];
+
+    component.movieFilter = 'alien';
+    expect(component.filteredMovies.length).toBe(1);
+    expect(component.filteredMovies[0].name).toBe('Alien');
+
+    component.movieFilter = '';
+    expect(component.filteredMovies.length).toBe(2);
+  }));
+
+  it('pagedMovies should respect moviesPerPage and currentPage', () => {
+    component.movies = Array.from({ length: 75 }, (_, i) => ({
+      name: `Movie ${i}`, year: 2000, overview: '', posterUrl: '',
+    }));
+    component.moviesPerPage = 50;
+    component.currentPage = 1;
+
+    expect(component.pagedMovies.length).toBe(50);
+    expect(component.totalPages).toBe(2);
+
+    component.currentPage = 2;
+    expect(component.pagedMovies.length).toBe(25);
+  });
+
+  it('applyFilter should group gaps by collection and filter owned/ignored', () => {
+    const gaps: CollectionGap[] = [
+      { tmdbId: 1, name: 'Alien', year: '1979', posterUrl: null, overview: '', collectionName: 'Alien Collection', owned: true },
+      { tmdbId: 2, name: 'Aliens', year: '1986', posterUrl: null, overview: '', collectionName: 'Alien Collection', owned: false },
+      { tmdbId: 3, name: 'Matrix', year: '1999', posterUrl: null, overview: '', collectionName: 'Matrix Collection', owned: false },
+    ];
+    component.allGaps = gaps;
+    component.showOwned = false;
+    component.showIgnored = false;
+    component.ignoredIds = new Set();
+
+    component.applyFilter();
+
+    // Without owned, should have 2 gaps in 2 groups
+    expect(component.collectionGroups.length).toBe(2);
+    expect(component.missingCount).toBe(2);
+
+    // With owned
+    component.showOwned = true;
+    component.applyFilter();
+    expect(component.collectionGroups.length).toBe(2);
+    const alienGroup = component.collectionGroups.find(g => g.name === 'Alien Collection');
+    expect(alienGroup?.gaps.length).toBe(2);
+  });
+
+  it('applyFilter should hide ignored movies when showIgnored is false', () => {
+    component.allGaps = [
+      { tmdbId: 1, name: 'Movie A', year: '2020', posterUrl: null, overview: '', collectionName: 'Coll', owned: false },
+      { tmdbId: 2, name: 'Movie B', year: '2021', posterUrl: null, overview: '', collectionName: 'Coll', owned: false },
+    ];
+    component.ignoredIds = new Set([1]);
+    component.showOwned = true;
+    component.showIgnored = false;
+
+    component.applyFilter();
+
+    expect(component.filteredGroups.length).toBe(1);
+    expect(component.filteredGroups[0].gaps.length).toBe(1);
+    expect(component.filteredGroups[0].gaps[0].tmdbId).toBe(2);
+  });
+
+  it('toggleIgnore should add/remove from ignored set', () => {
+    const gap: CollectionGap = { tmdbId: 42, name: 'Test', year: '2020', posterUrl: null, overview: '', collectionName: 'C', owned: false };
+    component.allGaps = [gap];
+    component.ignoredIds = new Set();
+    recommendationService.addIgnored.and.returnValue(of({}));
+    recommendationService.removeIgnored.and.returnValue(of({}));
+
+    const event = new Event('click');
+    component.toggleIgnore(gap, event);
+    expect(component.ignoredIds.has(42)).toBeTrue();
+
+    component.toggleIgnore(gap, event);
+    expect(component.ignoredIds.has(42)).toBeFalse();
+  });
+
+  it('toggleLibrarySelection should add/remove from selectedLibraries', () => {
+    component.selectedLibraries = ['Movies'];
+    component.toggleLibrarySelection('TV');
+    expect(component.selectedLibraries).toEqual(['Movies', 'TV']);
+
+    component.toggleLibrarySelection('Movies');
+    expect(component.selectedLibraries).toEqual(['TV']);
+  });
+
+  it('clearResults should reset all result state', () => {
+    component.selectedMovie = { name: 'Test', year: 2020, overview: '', posterUrl: '' };
+    component.scanMode = true;
+    component.allGaps = [{ tmdbId: 1, name: 'X', year: '2020', posterUrl: null, overview: '', collectionName: 'C', owned: false }];
+    component.errorMessage = 'some error';
+
+    component.clearResults();
+
+    expect(component.selectedMovie).toBeNull();
+    expect(component.scanMode).toBeFalse();
+    expect(component.allGaps).toEqual([]);
+    expect(component.collectionGroups).toEqual([]);
+    expect(component.errorMessage).toBe('');
+  });
+
+  it('scanLibrary with freshScan=true should show confirmation first', () => {
+    component.scanLibrary(true);
+    expect(component.showFreshScanConfirm).toBeTrue();
+  });
+
+  it('onFreshScanCancel should dismiss the confirmation', () => {
+    component.showFreshScanConfirm = true;
+    component.onFreshScanCancel();
+    expect(component.showFreshScanConfirm).toBeFalse();
+  });
+
+  it('searchFilter should filter collection groups by name or movie name', () => {
+    component.allGaps = [
+      { tmdbId: 1, name: 'Alien', year: '1979', posterUrl: null, overview: '', collectionName: 'Alien Collection', owned: false },
+      { tmdbId: 2, name: 'The Matrix', year: '1999', posterUrl: null, overview: '', collectionName: 'Matrix Collection', owned: false },
+    ];
+    component.showOwned = true;
+    component.showIgnored = true;
+    component.ignoredIds = new Set();
+
+    component.searchFilter = 'alien';
+    component.applyFilter();
+
+    expect(component.filteredGroups.length).toBe(1);
+    expect(component.filteredGroups[0].name).toBe('Alien Collection');
+  });
+
+  it('exportResults should call exportService with filtered gaps', () => {
+    component.filteredGroups = [{
+      name: 'Coll',
+      gaps: [{ tmdbId: 1, name: 'Movie', year: '2020', posterUrl: null, overview: '', collectionName: 'Coll', owned: false }],
+    }];
+
+    component.exportResults('csv');
+    expect(exportService.exportGaps).toHaveBeenCalledWith(
+      component.filteredGroups[0].gaps,
+      'csv'
+    );
+  });
+
+  it('should stop polling on destroy', () => {
+    (component as any).pollTimer = setInterval(() => {}, 1000);
+    component.ngOnDestroy();
+    expect((component as any).pollTimer).toBeNull();
   });
 });

--- a/frontend/src/app/components/settings/emby-settings/emby-settings.component.spec.ts
+++ b/frontend/src/app/components/settings/emby-settings/emby-settings.component.spec.ts
@@ -1,21 +1,188 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
-
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { FormsModule } from '@angular/forms';
 import { EmbySettingsComponent } from './emby-settings.component';
+import { environment } from '../../../../environments/environment';
 
 describe('EmbySettingsComponent', () => {
   let component: EmbySettingsComponent;
   let fixture: ComponentFixture<EmbySettingsComponent>;
+  let httpMock: HttpTestingController;
 
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      declarations: [EmbySettingsComponent]
-    });
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule, FormsModule],
+      declarations: [EmbySettingsComponent],
+    }).compileComponents();
+
     fixture = TestBed.createComponent(EmbySettingsComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  it('should load active server on init', fakeAsync(() => {
+    fixture.detectChanges();
+
+    const req = httpMock.expectOne(`${environment.apiUrl}/emby/active-server`);
+    req.flush({
+      server: 'My Emby',
+      libraries: [{ title: 'Movies', type: 'movie' }, { title: 'Music', type: 'music' }],
+    });
+    tick();
+
+    expect(component.hasActiveServer).toBeTrue();
+    expect(component.activeServer).toBe('My Emby');
+    expect(component.activeLibraries.length).toBe(2);
+  }));
+
+  it('connect should not proceed with empty credentials', () => {
+    component.serverUrl = '';
+    component.apiKey = '';
+    component.connect();
+    expect(component.step).toBe('idle');
+  });
+
+  it('connect should call API and update state on success', fakeAsync(() => {
+    fixture.detectChanges();
+    httpMock.expectOne(`${environment.apiUrl}/emby/active-server`).flush({});
+
+    component.serverUrl = 'http://emby:8096';
+    component.apiKey = 'key123';
+    component.connect();
+    expect(component.step).toBe('connecting');
+
+    const req = httpMock.expectOne(`${environment.apiUrl}/emby/connect`);
+    expect(req.request.body).toEqual({ serverUrl: 'http://emby:8096', apiKey: 'key123' });
+    req.flush({
+      connected: true,
+      serverName: 'EmbyServer',
+      libraries: [{ title: 'Films', type: 'movie', id: '1' }],
+    });
+    tick();
+
+    expect(component.step).toBe('connected');
+    expect(component.serverName).toBe('EmbyServer');
+    expect(component.libraries.length).toBe(1);
+  }));
+
+  it('connect should show error on failed connection', fakeAsync(() => {
+    fixture.detectChanges();
+    httpMock.expectOne(`${environment.apiUrl}/emby/active-server`).flush({});
+
+    component.serverUrl = 'http://bad';
+    component.apiKey = 'key';
+    component.connect();
+
+    const req = httpMock.expectOne(`${environment.apiUrl}/emby/connect`);
+    req.flush({ connected: false, serverName: '', libraries: [], error: 'Connection refused' });
+    tick();
+
+    expect(component.step).toBe('idle');
+    expect(component.statusMessage).toBe('Connection refused');
+    expect(component.statusType).toBe('error');
+  }));
+
+  it('save should call save API and reload active server', fakeAsync(() => {
+    fixture.detectChanges();
+    httpMock.expectOne(`${environment.apiUrl}/emby/active-server`).flush({});
+
+    component.serverUrl = 'http://emby:8096';
+    component.apiKey = 'key';
+    component.serverName = 'EmbyServer';
+    component.libraries = [{ title: 'Movies', type: 'movie' }];
+    component.save();
+    expect(component.step).toBe('saving');
+
+    const saveReq = httpMock.expectOne(`${environment.apiUrl}/emby/save`);
+    saveReq.flush({ result: 'ok' });
+    tick();
+
+    const reloadReq = httpMock.expectOne(`${environment.apiUrl}/emby/active-server`);
+    reloadReq.flush({ server: 'EmbyServer', libraries: [] });
+    tick();
+
+    expect(component.step).toBe('idle');
+    expect(component.statusType).toBe('success');
+  }));
+
+  it('should filter movie libraries', () => {
+    component.libraries = [
+      { title: 'Movies', type: 'movie' },
+      { title: 'Music', type: 'music' },
+    ];
+    expect(component.movieLibraries.length).toBe(1);
+    expect(component.movieLibraries[0].title).toBe('Movies');
+  });
+
+  it('should filter active movie vs other libraries', () => {
+    component.activeLibraries = [
+      { title: 'Movies', type: 'movie' },
+      { title: 'TV', type: 'show' },
+      { title: 'Anime', type: 'movie' },
+    ];
+    expect(component.activeMovieLibraries.length).toBe(2);
+    expect(component.activeOtherLibraries.length).toBe(1);
+  });
+
+  it('should toggle API key visibility', () => {
+    expect(component.apiKeyVisible).toBeFalse();
+    component.toggleApiKeyVisibility();
+    expect(component.apiKeyVisible).toBeTrue();
+  });
+
+  it('removeServer should DELETE and reset state', fakeAsync(() => {
+    fixture.detectChanges();
+    httpMock.expectOne(`${environment.apiUrl}/emby/active-server`).flush({});
+
+    component.hasActiveServer = true;
+    component.removeServer();
+
+    const req = httpMock.expectOne({
+      method: 'DELETE',
+      url: `${environment.apiUrl}/emby/active-server`,
+    });
+    req.flush({ result: 'ok' });
+    tick();
+
+    expect(component.hasActiveServer).toBeFalse();
+    expect(component.activeServer).toBe('');
+    expect(component.statusType).toBe('success');
+  }));
+
+  it('testConnection should show success when connected', fakeAsync(() => {
+    fixture.detectChanges();
+    httpMock.expectOne(`${environment.apiUrl}/emby/active-server`).flush({});
+
+    component.testConnection();
+    expect(component.testing).toBeTrue();
+
+    const req = httpMock.expectOne(`${environment.apiUrl}/emby/test-active`);
+    req.flush({ connected: true });
+    tick();
+
+    expect(component.testing).toBeFalse();
+    expect(component.statusMessage).toBe('Connection successful!');
+  }));
+
+  it('testConnection should show error when not connected', fakeAsync(() => {
+    fixture.detectChanges();
+    httpMock.expectOne(`${environment.apiUrl}/emby/active-server`).flush({});
+
+    component.testConnection();
+    const req = httpMock.expectOne(`${environment.apiUrl}/emby/test-active`);
+    req.flush({ connected: false, error: 'Timeout' });
+    tick();
+
+    expect(component.testing).toBeFalse();
+    expect(component.statusMessage).toBe('Timeout');
+    expect(component.statusType).toBe('error');
+  }));
 });

--- a/frontend/src/app/components/settings/jellyfin-settings/jellyfin-settings.component.spec.ts
+++ b/frontend/src/app/components/settings/jellyfin-settings/jellyfin-settings.component.spec.ts
@@ -1,21 +1,165 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
-
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { FormsModule } from '@angular/forms';
 import { JellyfinSettingsComponent } from './jellyfin-settings.component';
+import { environment } from '../../../../environments/environment';
 
 describe('JellyfinSettingsComponent', () => {
   let component: JellyfinSettingsComponent;
   let fixture: ComponentFixture<JellyfinSettingsComponent>;
+  let httpMock: HttpTestingController;
 
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      declarations: [JellyfinSettingsComponent]
-    });
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule, FormsModule],
+      declarations: [JellyfinSettingsComponent],
+    }).compileComponents();
+
     fixture = TestBed.createComponent(JellyfinSettingsComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  it('should load active server on init', fakeAsync(() => {
+    fixture.detectChanges();
+
+    const req = httpMock.expectOne(`${environment.apiUrl}/jellyfin/active-server`);
+    req.flush({
+      server: 'My Jellyfin',
+      libraries: [{ title: 'Films', type: 'movie' }],
+    });
+    tick();
+
+    expect(component.hasActiveServer).toBeTrue();
+    expect(component.activeServer).toBe('My Jellyfin');
+    expect(component.activeLibraries.length).toBe(1);
+  }));
+
+  it('connect should not proceed with empty credentials', () => {
+    component.serverUrl = '';
+    component.apiKey = '';
+    component.connect();
+    expect(component.step).toBe('idle');
+  });
+
+  it('connect should call API and update state on success', fakeAsync(() => {
+    fixture.detectChanges();
+    httpMock.expectOne(`${environment.apiUrl}/jellyfin/active-server`).flush({});
+
+    component.serverUrl = 'http://jellyfin:8096';
+    component.apiKey = 'key123';
+    component.connect();
+    expect(component.step).toBe('connecting');
+
+    const req = httpMock.expectOne(`${environment.apiUrl}/jellyfin/connect`);
+    expect(req.request.body).toEqual({ serverUrl: 'http://jellyfin:8096', apiKey: 'key123' });
+    req.flush({
+      connected: true,
+      serverName: 'JellyServer',
+      libraries: [{ title: 'Movies', type: 'movie', id: '1' }],
+    });
+    tick();
+
+    expect(component.step).toBe('connected');
+    expect(component.serverName).toBe('JellyServer');
+    expect(component.libraries.length).toBe(1);
+  }));
+
+  it('connect should show error on failed connection', fakeAsync(() => {
+    fixture.detectChanges();
+    httpMock.expectOne(`${environment.apiUrl}/jellyfin/active-server`).flush({});
+
+    component.serverUrl = 'http://bad';
+    component.apiKey = 'key';
+    component.connect();
+
+    const req = httpMock.expectOne(`${environment.apiUrl}/jellyfin/connect`);
+    req.flush({ connected: false, serverName: '', libraries: [], error: 'Connection refused' });
+    tick();
+
+    expect(component.step).toBe('idle');
+    expect(component.statusMessage).toBe('Connection refused');
+    expect(component.statusType).toBe('error');
+  }));
+
+  it('save should call save API and reload active server', fakeAsync(() => {
+    fixture.detectChanges();
+    httpMock.expectOne(`${environment.apiUrl}/jellyfin/active-server`).flush({});
+
+    component.serverUrl = 'http://jellyfin:8096';
+    component.apiKey = 'key';
+    component.serverName = 'JellyServer';
+    component.libraries = [{ title: 'Movies', type: 'movie' }];
+    component.save();
+    expect(component.step).toBe('saving');
+
+    const saveReq = httpMock.expectOne(`${environment.apiUrl}/jellyfin/save`);
+    saveReq.flush({ result: 'ok' });
+    tick();
+
+    // loadActiveServer fires again after save
+    const reloadReq = httpMock.expectOne(`${environment.apiUrl}/jellyfin/active-server`);
+    reloadReq.flush({ server: 'JellyServer', libraries: [] });
+    tick();
+
+    expect(component.step).toBe('idle');
+    expect(component.statusType).toBe('success');
+  }));
+
+  it('should filter movie libraries', () => {
+    component.libraries = [
+      { title: 'Movies', type: 'movie' },
+      { title: 'TV', type: 'show' },
+    ];
+    expect(component.movieLibraries.length).toBe(1);
+    expect(component.movieLibraries[0].title).toBe('Movies');
+  });
+
+  it('should toggle API key visibility', () => {
+    expect(component.apiKeyVisible).toBeFalse();
+    component.toggleApiKeyVisibility();
+    expect(component.apiKeyVisible).toBeTrue();
+  });
+
+  it('removeServer should DELETE and reset state', fakeAsync(() => {
+    fixture.detectChanges();
+    httpMock.expectOne(`${environment.apiUrl}/jellyfin/active-server`).flush({});
+
+    component.hasActiveServer = true;
+    component.removeServer();
+
+    const req = httpMock.expectOne({
+      method: 'DELETE',
+      url: `${environment.apiUrl}/jellyfin/active-server`,
+    });
+    req.flush({ result: 'ok' });
+    tick();
+
+    expect(component.hasActiveServer).toBeFalse();
+    expect(component.activeServer).toBe('');
+    expect(component.statusType).toBe('success');
+  }));
+
+  it('testConnection should show success when connected', fakeAsync(() => {
+    fixture.detectChanges();
+    httpMock.expectOne(`${environment.apiUrl}/jellyfin/active-server`).flush({});
+
+    component.testConnection();
+    expect(component.testing).toBeTrue();
+
+    const req = httpMock.expectOne(`${environment.apiUrl}/jellyfin/test-active`);
+    req.flush({ connected: true });
+    tick();
+
+    expect(component.testing).toBeFalse();
+    expect(component.statusMessage).toBe('Connection successful!');
+  }));
 });

--- a/frontend/src/app/components/settings/plex-settings/plex-settings.component.spec.ts
+++ b/frontend/src/app/components/settings/plex-settings/plex-settings.component.spec.ts
@@ -1,21 +1,151 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
-
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { FormsModule } from '@angular/forms';
 import { PlexSettingsComponent } from './plex-settings.component';
+import { environment } from '../../../../environments/environment';
 
 describe('PlexSettingsComponent', () => {
   let component: PlexSettingsComponent;
   let fixture: ComponentFixture<PlexSettingsComponent>;
+  let httpMock: HttpTestingController;
 
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      declarations: [PlexSettingsComponent]
-    });
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule, FormsModule],
+      declarations: [PlexSettingsComponent],
+    }).compileComponents();
+
     fixture = TestBed.createComponent(PlexSettingsComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  it('should load active server on init', fakeAsync(() => {
+    fixture.detectChanges();
+
+    const req = httpMock.expectOne(`${environment.apiUrl}/plex/active-server`);
+    req.flush({
+      server: 'My Plex',
+      token: 'tok123',
+      libraries: [{ title: 'Movies', type: 'movie' }, { title: 'TV', type: 'show' }],
+    });
+    tick();
+
+    expect(component.hasActiveServer).toBeTrue();
+    expect(component.activeServer).toBe('My Plex');
+    expect(component.activeLibraries.length).toBe(2);
+    expect(component.plexToken).toBe('tok123');
+  }));
+
+  it('should start with idle step and choose connection mode', () => {
+    expect(component.step).toBe('idle');
+    expect(component.connectionMode).toBe('choose');
+  });
+
+  it('should filter movie libraries from all libraries', fakeAsync(() => {
+    fixture.detectChanges();
+    httpMock.expectOne(`${environment.apiUrl}/plex/active-server`).flush({});
+
+    component.libraries = [
+      { title: 'Movies', type: 'movie' },
+      { title: 'TV Shows', type: 'show' },
+      { title: 'Anime', type: 'movie' },
+    ];
+
+    expect(component.movieLibraries.length).toBe(2);
+    expect(component.movieLibraries.map(l => l.title)).toEqual(['Movies', 'Anime']);
+  }));
+
+  it('isLoading should return true for loading steps', () => {
+    component.step = 'authenticating';
+    expect(component.isLoading).toBeTrue();
+    component.step = 'fetching';
+    expect(component.isLoading).toBeTrue();
+    component.step = 'saving';
+    expect(component.isLoading).toBeTrue();
+    component.step = 'manual-connecting';
+    expect(component.isLoading).toBeTrue();
+    component.step = 'idle';
+    expect(component.isLoading).toBeFalse();
+    component.step = 'selecting';
+    expect(component.isLoading).toBeFalse();
+  });
+
+  it('should toggle token visibility', () => {
+    expect(component.tokenVisible).toBeFalse();
+    component.togglePlexTokenVisibility();
+    expect(component.tokenVisible).toBeTrue();
+    component.togglePlexTokenVisibility();
+    expect(component.tokenVisible).toBeFalse();
+  });
+
+  it('disconnect should clear active server state', () => {
+    component.hasActiveServer = true;
+    component.activeServer = 'Server';
+    component.disconnect();
+
+    expect(component.hasActiveServer).toBeFalse();
+    expect(component.activeServer).toBe('');
+    expect(component.step).toBe('idle');
+    expect(component.connectionMode).toBe('choose');
+  });
+
+  it('removeServer should call DELETE and reset state on success', fakeAsync(() => {
+    fixture.detectChanges();
+    httpMock.expectOne(`${environment.apiUrl}/plex/active-server`).flush({});
+
+    component.hasActiveServer = true;
+    component.activeServer = 'Server';
+    component.removeServer();
+
+    const req = httpMock.expectOne({
+      method: 'DELETE',
+      url: `${environment.apiUrl}/plex/active-server`,
+    });
+    req.flush({ result: 'ok' });
+    tick();
+
+    expect(component.hasActiveServer).toBeFalse();
+    expect(component.activeServer).toBe('');
+    expect(component.statusType).toBe('success');
+  }));
+
+  it('testConnection should POST and show success when connected', fakeAsync(() => {
+    fixture.detectChanges();
+    httpMock.expectOne(`${environment.apiUrl}/plex/active-server`).flush({});
+
+    component.testConnection();
+    expect(component.testing).toBeTrue();
+
+    const req = httpMock.expectOne(`${environment.apiUrl}/plex/test-active`);
+    expect(req.request.method).toBe('POST');
+    req.flush({ connected: true, serverName: 'My Plex' });
+    tick();
+
+    expect(component.testing).toBeFalse();
+    expect(component.statusMessage).toBe('Connection successful!');
+    expect(component.statusType).toBe('success');
+  }));
+
+  it('testConnection should show error when not connected', fakeAsync(() => {
+    fixture.detectChanges();
+    httpMock.expectOne(`${environment.apiUrl}/plex/active-server`).flush({});
+
+    component.testConnection();
+    const req = httpMock.expectOne(`${environment.apiUrl}/plex/test-active`);
+    req.flush({ connected: false, error: 'Server unreachable' });
+    tick();
+
+    expect(component.testing).toBeFalse();
+    expect(component.statusMessage).toBe('Server unreachable');
+    expect(component.statusType).toBe('error');
+  }));
 });

--- a/frontend/src/app/components/settings/settings.component.spec.ts
+++ b/frontend/src/app/components/settings/settings.component.spec.ts
@@ -1,15 +1,17 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
+import { RouterTestingModule } from '@angular/router/testing';
 import { SettingsComponent } from './settings.component';
 
 describe('SettingsComponent', () => {
   let component: SettingsComponent;
   let fixture: ComponentFixture<SettingsComponent>;
 
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      declarations: [SettingsComponent]
-    });
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [RouterTestingModule],
+      declarations: [SettingsComponent],
+    }).compileComponents();
+
     fixture = TestBed.createComponent(SettingsComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
@@ -17,5 +19,10 @@ describe('SettingsComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should contain a router-outlet for child settings routes', () => {
+    const el = fixture.nativeElement as HTMLElement;
+    expect(el.querySelector('router-outlet')).toBeTruthy();
   });
 });

--- a/frontend/src/app/components/settings/tmdb-settings/tmdb-settings.component.spec.ts
+++ b/frontend/src/app/components/settings/tmdb-settings/tmdb-settings.component.spec.ts
@@ -1,21 +1,106 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
-
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { ReactiveFormsModule } from '@angular/forms';
 import { TmdbSettingsComponent } from './tmdb-settings.component';
+import { environment } from '../../../../environments/environment';
 
 describe('TmdbSettingsComponent', () => {
   let component: TmdbSettingsComponent;
   let fixture: ComponentFixture<TmdbSettingsComponent>;
+  let httpMock: HttpTestingController;
 
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      declarations: [TmdbSettingsComponent]
-    });
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule, ReactiveFormsModule],
+      declarations: [TmdbSettingsComponent],
+    }).compileComponents();
+
     fixture = TestBed.createComponent(TmdbSettingsComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  it('should load TMDB status on init and populate the form if a key exists', fakeAsync(() => {
+    fixture.detectChanges();
+
+    const req = httpMock.expectOne(`${environment.apiUrl}/tmdb/status`);
+    req.flush({ hasKey: true, apiKey: 'existing-key' });
+    tick();
+
+    expect(component.hasKey).toBeTrue();
+    expect(component.tmdbForm.get('movieDbApiKey')?.value).toBe('existing-key');
+  }));
+
+  it('should show error when testing with empty key', fakeAsync(() => {
+    fixture.detectChanges();
+    httpMock.expectOne(`${environment.apiUrl}/tmdb/status`).flush({ hasKey: false, apiKey: '' });
+    tick();
+
+    component.testTmdbKey();
+
+    expect(component.message).toBe('Please enter an API key first.');
+    expect(component.messageType).toBe('error');
+  }));
+
+  it('should call test-key API and show success on valid key', fakeAsync(() => {
+    fixture.detectChanges();
+    httpMock.expectOne(`${environment.apiUrl}/tmdb/status`).flush({ hasKey: false, apiKey: '' });
+    tick();
+
+    component.tmdbForm.patchValue({ movieDbApiKey: 'valid-key' });
+    component.testTmdbKey();
+    expect(component.testing).toBeTrue();
+
+    const req = httpMock.expectOne(`${environment.apiUrl}/tmdb/test-key`);
+    expect(req.request.body).toEqual({ api_key: 'valid-key' });
+    req.flush({ message: 'API key is working!' });
+    tick();
+
+    expect(component.testing).toBeFalse();
+    expect(component.message).toBe('API key is working!');
+    expect(component.messageType).toBe('success');
+  }));
+
+  it('should call save-key API and update hasKey on success', fakeAsync(() => {
+    fixture.detectChanges();
+    httpMock.expectOne(`${environment.apiUrl}/tmdb/status`).flush({ hasKey: false, apiKey: '' });
+    tick();
+
+    component.tmdbForm.patchValue({ movieDbApiKey: 'new-key' });
+    component.saveTmdbKey();
+    expect(component.saving).toBeTrue();
+
+    const req = httpMock.expectOne(`${environment.apiUrl}/tmdb/save-key`);
+    expect(req.request.body).toEqual({ key: 'new-key' });
+    req.flush({ message: 'Saved!' });
+    tick();
+
+    expect(component.saving).toBeFalse();
+    expect(component.hasKey).toBeTrue();
+    expect(component.messageType).toBe('success');
+  }));
+
+  it('should handle save-key API error', fakeAsync(() => {
+    fixture.detectChanges();
+    httpMock.expectOne(`${environment.apiUrl}/tmdb/status`).flush({ hasKey: false, apiKey: '' });
+    tick();
+
+    component.tmdbForm.patchValue({ movieDbApiKey: 'bad-key' });
+    component.saveTmdbKey();
+
+    const req = httpMock.expectOne(`${environment.apiUrl}/tmdb/save-key`);
+    req.flush({ error: 'Invalid key' }, { status: 400, statusText: 'Bad Request' });
+    tick();
+
+    expect(component.saving).toBeFalse();
+    expect(component.messageType).toBe('error');
+  }));
 });

--- a/frontend/src/app/components/settings/user-preferences-settings/user-preferences-settings.component.html
+++ b/frontend/src/app/components/settings/user-preferences-settings/user-preferences-settings.component.html
@@ -77,6 +77,13 @@
       </label>
     </div>
 
+    <!-- Media Server Timeout -->
+    <div class="pref-card mb-3">
+      <h5>Media Server Timeout</h5>
+      <p class="text-muted small">Timeout in seconds for requests to Plex, Emby, and Jellyfin. Increase for large libraries (3000+ movies).</p>
+      <input type="number" class="form-control dark-input" [(ngModel)]="prefs.mediaServerTimeout" min="10" max="300">
+    </div>
+
     <!-- Save Button -->
     <div class="mt-4 mb-4">
       <button class="btn btn-success" (click)="save()" [disabled]="saving">

--- a/frontend/src/app/components/settings/user-preferences-settings/user-preferences-settings.component.spec.ts
+++ b/frontend/src/app/components/settings/user-preferences-settings/user-preferences-settings.component.spec.ts
@@ -1,21 +1,129 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
-
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { FormsModule } from '@angular/forms';
 import { UserPreferencesSettingsComponent } from './user-preferences-settings.component';
+import { environment } from '../../../../environments/environment';
 
 describe('UserPreferencesSettingsComponent', () => {
   let component: UserPreferencesSettingsComponent;
   let fixture: ComponentFixture<UserPreferencesSettingsComponent>;
+  let httpMock: HttpTestingController;
 
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      declarations: [UserPreferencesSettingsComponent]
-    });
+  const defaultPrefs = {
+    defaultLibrary: '',
+    moviesPerPage: 50,
+    hideOwnedByDefault: false,
+    language: 'en',
+    port: 5000,
+    autoOpenBrowser: true,
+    posterPrefetch: false,
+    imageCacheEnabled: false,
+    mediaServerTimeout: 30,
+  };
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule, FormsModule],
+      declarations: [UserPreferencesSettingsComponent],
+    }).compileComponents();
+
     fixture = TestBed.createComponent(UserPreferencesSettingsComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
+    httpMock = TestBed.inject(HttpTestingController);
   });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  function initComponent() {
+    fixture.detectChanges();
+    // Respond to preferences load
+    httpMock.expectOne(`${environment.apiUrl}/preferences`).flush(defaultPrefs);
+    // Respond to media server checks
+    httpMock.expectOne(`${environment.apiUrl}/plex/active-server`).flush({});
+    httpMock.expectOne(`${environment.apiUrl}/jellyfin/active-server`).flush({});
+    httpMock.expectOne(`${environment.apiUrl}/emby/active-server`).flush({});
+  }
 
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  it('should load preferences on init and set loading to false', fakeAsync(() => {
+    initComponent();
+    tick();
+
+    expect(component.loading).toBeFalse();
+    expect(component.prefs.moviesPerPage).toBe(50);
+    expect(component.prefs.language).toBe('en');
+    expect(component.prefs.mediaServerTimeout).toBe(30);
+  }));
+
+  it('should populate libraries from active media server', fakeAsync(() => {
+    fixture.detectChanges();
+    httpMock.expectOne(`${environment.apiUrl}/preferences`).flush(defaultPrefs);
+    httpMock.expectOne(`${environment.apiUrl}/plex/active-server`).flush({
+      server: 'My Plex',
+      libraries: [
+        { title: 'Movies', type: 'movie' },
+        { title: 'TV', type: 'show' },
+      ],
+    });
+    httpMock.expectOne(`${environment.apiUrl}/jellyfin/active-server`).flush({});
+    httpMock.expectOne(`${environment.apiUrl}/emby/active-server`).flush({});
+    tick();
+
+    // Only movie libraries should be included
+    expect(component.libraries.length).toBe(1);
+    expect(component.libraries[0].title).toBe('Movies');
+  }));
+
+  it('should save preferences and show success', fakeAsync(() => {
+    initComponent();
+    tick();
+
+    component.prefs.moviesPerPage = 100;
+    component.prefs.mediaServerTimeout = 60;
+    component.save();
+
+    expect(component.saving).toBeTrue();
+
+    const req = httpMock.expectOne(`${environment.apiUrl}/preferences`);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body.moviesPerPage).toBe(100);
+    expect(req.request.body.mediaServerTimeout).toBe(60);
+
+    req.flush({ ...defaultPrefs, moviesPerPage: 100, mediaServerTimeout: 60 });
+    tick();
+
+    expect(component.saving).toBeFalse();
+    expect(component.saved).toBeTrue();
+    expect(component.prefs.moviesPerPage).toBe(100);
+    expect(component.prefs.mediaServerTimeout).toBe(60);
+  }));
+
+  it('should have expected language options', () => {
+    expect(component.languages.length).toBeGreaterThan(5);
+    expect(component.languages.some(l => l.code === 'en' && l.name === 'English')).toBeTrue();
+    expect(component.languages.some(l => l.code === 'fr' && l.name === 'French')).toBeTrue();
+  });
+
+  it('should have expected page size options', () => {
+    expect(component.pageSizeOptions).toEqual([25, 50, 100, 200]);
+  });
+
+  it('should handle save error gracefully', fakeAsync(() => {
+    initComponent();
+    tick();
+
+    component.save();
+
+    const req = httpMock.expectOne(`${environment.apiUrl}/preferences`);
+    req.error(new ProgressEvent('Network error'));
+    tick();
+
+    expect(component.saving).toBeFalse();
+    expect(component.saved).toBeFalse();
+  }));
 });

--- a/frontend/src/app/components/settings/user-preferences-settings/user-preferences-settings.component.ts
+++ b/frontend/src/app/components/settings/user-preferences-settings/user-preferences-settings.component.ts
@@ -23,6 +23,7 @@ export class UserPreferencesSettingsComponent implements OnInit {
     autoOpenBrowser: true,
     posterPrefetch: false,
     imageCacheEnabled: false,
+    mediaServerTimeout: 30,
   };
 
   libraries: MediaLibrary[] = [];

--- a/frontend/src/app/components/updates/updates.component.spec.ts
+++ b/frontend/src/app/components/updates/updates.component.spec.ts
@@ -1,21 +1,61 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
-
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { UpdatesComponent } from './updates.component';
 
 describe('UpdatesComponent', () => {
   let component: UpdatesComponent;
   let fixture: ComponentFixture<UpdatesComponent>;
+  let httpMock: HttpTestingController;
 
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      declarations: [UpdatesComponent]
-    });
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      declarations: [UpdatesComponent],
+    }).compileComponents();
+
     fixture = TestBed.createComponent(UpdatesComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  it('should start in loading state', () => {
+    expect(component.loading).toBeTrue();
+    expect(component.releases).toEqual([]);
+  });
+
+  it('should load releases on init', fakeAsync(() => {
+    fixture.detectChanges();
+
+    const req = httpMock.expectOne('https://api.github.com/repos/primetime43/GAPS-2/releases');
+    req.flush([{
+      tag_name: 'v2.0.0',
+      name: 'Release 2.0.0',
+      body: 'Initial release',
+      published_at: '2025-01-01T00:00:00Z',
+      html_url: 'https://example.com',
+    }]);
+    tick();
+
+    expect(component.loading).toBeFalse();
+    expect(component.releases.length).toBe(1);
+  }));
+
+  it('should handle error when loading releases', fakeAsync(() => {
+    fixture.detectChanges();
+
+    const req = httpMock.expectOne('https://api.github.com/repos/primetime43/GAPS-2/releases');
+    req.error(new ProgressEvent('Network error'));
+    tick();
+
+    expect(component.loading).toBeFalse();
+    expect(component.error).toBe('Could not load releases from GitHub.');
+  }));
 });

--- a/frontend/src/app/index/index.component.spec.ts
+++ b/frontend/src/app/index/index.component.spec.ts
@@ -1,21 +1,146 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
-
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { RouterTestingModule } from '@angular/router/testing';
 import { IndexComponent } from './index.component';
+import { environment } from '../../environments/environment';
 
 describe('IndexComponent', () => {
   let component: IndexComponent;
   let fixture: ComponentFixture<IndexComponent>;
+  let httpMock: HttpTestingController;
 
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      declarations: [IndexComponent]
-    });
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule, RouterTestingModule],
+      declarations: [IndexComponent],
+    }).compileComponents();
+
     fixture = TestBed.createComponent(IndexComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
+    httpMock = TestBed.inject(HttpTestingController);
   });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  function flushInitRequests(options?: {
+    tmdb?: { hasKey: boolean };
+    plex?: any;
+    jellyfin?: any;
+    emby?: any;
+    schedule?: any;
+    progress?: any;
+  }) {
+    fixture.detectChanges();
+
+    httpMock.expectOne(`${environment.apiUrl}/tmdb/status`)
+      .flush(options?.tmdb ?? { hasKey: false, apiKey: '' });
+    httpMock.expectOne(`${environment.apiUrl}/plex/active-server`)
+      .flush(options?.plex ?? {});
+    httpMock.expectOne(`${environment.apiUrl}/jellyfin/active-server`)
+      .flush(options?.jellyfin ?? {});
+    httpMock.expectOne(`${environment.apiUrl}/emby/active-server`)
+      .flush(options?.emby ?? {});
+    httpMock.expectOne(`${environment.apiUrl}/schedule`)
+      .flush(options?.schedule ?? { enabled: false, preset: '', next_run: null, presets: {} });
+    httpMock.expectOne(`${environment.apiUrl}/recommendations/scan/progress`)
+      .flush(options?.progress ?? { status: 'idle' });
+  }
 
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  it('should start in loading state', () => {
+    expect(component.loading).toBeTrue();
+    expect(component.tmdbConfigured).toBeFalse();
+    expect(component.mediaServerConnected).toBeFalse();
+  });
+
+  it('should detect TMDB is configured', fakeAsync(() => {
+    flushInitRequests({ tmdb: { hasKey: true } });
+    tick();
+
+    expect(component.tmdbConfigured).toBeTrue();
+  }));
+
+  it('should detect Plex as connected media server', fakeAsync(() => {
+    flushInitRequests({
+      plex: { server: 'My Plex', libraries: [] },
+    });
+    tick();
+
+    expect(component.mediaServerConnected).toBeTrue();
+    expect(component.mediaServerName).toBe('My Plex');
+    expect(component.mediaServerType).toBe('Plex');
+    expect(component.loading).toBeFalse();
+  }));
+
+  it('should detect Jellyfin as connected media server', fakeAsync(() => {
+    flushInitRequests({
+      jellyfin: { server: 'My Jellyfin', libraries: [] },
+    });
+    tick();
+
+    expect(component.mediaServerConnected).toBeTrue();
+    expect(component.mediaServerName).toBe('My Jellyfin');
+    expect(component.mediaServerType).toBe('Jellyfin');
+  }));
+
+  it('should detect Emby as connected media server', fakeAsync(() => {
+    flushInitRequests({
+      emby: { server: 'My Emby', libraries: [] },
+    });
+    tick();
+
+    expect(component.mediaServerConnected).toBeTrue();
+    expect(component.mediaServerName).toBe('My Emby');
+    expect(component.mediaServerType).toBe('Emby');
+  }));
+
+  it('should prioritize Plex over Jellyfin and Emby', fakeAsync(() => {
+    flushInitRequests({
+      plex: { server: 'Plex', libraries: [] },
+      jellyfin: { server: 'Jellyfin', libraries: [] },
+      emby: { server: 'Emby', libraries: [] },
+    });
+    tick();
+
+    expect(component.mediaServerType).toBe('Plex');
+  }));
+
+  it('should show no server connected when none are active', fakeAsync(() => {
+    flushInitRequests();
+    tick();
+
+    expect(component.mediaServerConnected).toBeFalse();
+    expect(component.loading).toBeFalse();
+  }));
+
+  it('should load schedule status', fakeAsync(() => {
+    flushInitRequests({
+      schedule: { enabled: true, preset: 'daily', next_run: '2026-04-07T00:00:00Z', presets: {} },
+    });
+    tick();
+
+    expect(component.scheduleEnabled).toBeTrue();
+    expect(component.schedulePreset).toBe('daily');
+    expect(component.nextRun).toBe('2026-04-07T00:00:00Z');
+  }));
+
+  it('should load last scan status when scan is done', fakeAsync(() => {
+    flushInitRequests({
+      progress: {
+        status: 'done',
+        gaps: [{ tmdbId: 1 }, { tmdbId: 2 }],
+        total_owned: 500,
+      },
+    });
+    tick();
+
+    expect(component.lastScanStatus).toBe('done');
+    expect(component.lastScanGaps).toBe(2);
+    expect(component.lastScanTotal).toBe(500);
+  }));
 });

--- a/frontend/src/app/services/preferences.service.ts
+++ b/frontend/src/app/services/preferences.service.ts
@@ -12,6 +12,7 @@ export interface UserPreferences {
   autoOpenBrowser: boolean;
   posterPrefetch: boolean;
   imageCacheEnabled: boolean;
+  mediaServerTimeout: number;
 }
 
 @Injectable({

--- a/frontend/src/app/services/tmdb/tmdb.service.spec.ts
+++ b/frontend/src/app/services/tmdb/tmdb.service.spec.ts
@@ -1,16 +1,60 @@
 import { TestBed } from '@angular/core/testing';
-
-import { TmdbService } from './tmdb.service';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { TmdbService, TmdbStatus } from './tmdb.service';
+import { environment } from '../../../environments/environment';
 
 describe('TmdbService', () => {
   let service: TmdbService;
+  let httpMock: HttpTestingController;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+    });
     service = TestBed.inject(TmdbService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
   });
 
   it('should be created', () => {
     expect(service).toBeTruthy();
+  });
+
+  it('getStatus should GET tmdb/status and return hasKey and apiKey', () => {
+    const mockStatus: TmdbStatus = { hasKey: true, apiKey: 'abc123' };
+
+    service.getStatus().subscribe(status => {
+      expect(status.hasKey).toBeTrue();
+      expect(status.apiKey).toBe('abc123');
+    });
+
+    const req = httpMock.expectOne(`${environment.apiUrl}/tmdb/status`);
+    expect(req.request.method).toBe('GET');
+    req.flush(mockStatus);
+  });
+
+  it('testApiKey should POST the key to tmdb/test-key', () => {
+    service.testApiKey('mykey').subscribe(res => {
+      expect(res.message).toBe('API key is valid!');
+    });
+
+    const req = httpMock.expectOne(`${environment.apiUrl}/tmdb/test-key`);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual({ api_key: 'mykey' });
+    req.flush({ message: 'API key is valid!' });
+  });
+
+  it('saveApiKey should POST the key to tmdb/save-key', () => {
+    service.saveApiKey('mykey').subscribe(res => {
+      expect(res.message).toBe('Saved!');
+    });
+
+    const req = httpMock.expectOne(`${environment.apiUrl}/tmdb/save-key`);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual({ key: 'mykey' });
+    req.flush({ message: 'Saved!' });
   });
 });

--- a/frontend/src/environments/environment.prod.ts
+++ b/frontend/src/environments/environment.prod.ts
@@ -1,5 +1,5 @@
 export const environment = {
   production: true,
   apiUrl: '/api',
-  version: '2.1.1'
+  version: '2.2.0'
 };

--- a/frontend/src/environments/environment.ts
+++ b/frontend/src/environments/environment.ts
@@ -1,5 +1,5 @@
 export const environment = {
   production: false,
   apiUrl: '/api',
-  version: '2.1.1'
+  version: '2.2.0'
 };


### PR DESCRIPTION
This pull request introduces a configurable timeout for media server requests, improves test coverage and structure in the frontend, and enhances the UI for recommended movies by adding direct links to TMDB when available. The main changes are grouped below:

**Backend: Media Server Timeout Configuration**
* Added a new `mediaServerTimeout` preference (default 30 seconds) to allow users to configure the timeout for requests to Jellyfin, Emby, and Plex servers. All relevant service calls now use this configurable timeout instead of a hardcoded value. [[1]](diffhunk://#diff-19347187e1b1846e057c0ac2f7f198c55d7e468dc702466939cec2a61459a854R15) [[2]](diffhunk://#diff-cd74eba6e047fb33c844854d05fc757723528dae3225855e7e5997b25e3e8e43L198-R200) [[3]](diffhunk://#diff-cf20ff45c032729bee6ff1d95c27a0f097d6d639423cb85bd4a5693ca06077a8L198-R200) [[4]](diffhunk://#diff-da8b2b8f8fcb66e1cb62498072786e87abd27047043bf74b7d05b644389d37a8R43-R50) [[5]](diffhunk://#diff-da8b2b8f8fcb66e1cb62498072786e87abd27047043bf74b7d05b644389d37a8L105-R109) [[6]](diffhunk://#diff-da8b2b8f8fcb66e1cb62498072786e87abd27047043bf74b7d05b644389d37a8L116-R120)

**Backend: Recommendations Logic Refactor**
* Refactored the recommendations blueprint to use a more flexible `_get_service` helper, and improved the logic for refreshing the movies cache and scanning library gaps. This ensures fresh scans clear and reload the cache properly. [[1]](diffhunk://#diff-f530e18fc407290b32253c6e64c5857aa119379d8ccb5af8a5f20fd6694f1c37L7-R19) [[2]](diffhunk://#diff-f530e18fc407290b32253c6e64c5857aa119379d8ccb5af8a5f20fd6694f1c37L84-R99) [[3]](diffhunk://#diff-f530e18fc407290b32253c6e64c5857aa119379d8ccb5af8a5f20fd6694f1c37L103-L105)

**Frontend: Improved Test Coverage and Structure**
* Updated and expanded unit tests for `AppComponent`, `HeaderComponent`, and `AboutComponent`, including the use of Angular's testing utilities, HTTP mocking, and more comprehensive assertions for UI elements and error handling. [[1]](diffhunk://#diff-e70e7f47151bbead63fc2a37b7c56ace1178f462f899ceebba09189ea8f2a00fL2-R32) [[2]](diffhunk://#diff-be6b7d42f45bf9fd1a93f1f1f0782b520c51ab34bebf97c69818a0de0d4a16dfL1-R72) [[3]](diffhunk://#diff-096d94fef639b56e50a4d6c509eb10a86efa236a396ebcffa804d0e5cee08dcfL2-R14) [[4]](diffhunk://#diff-096d94fef639b56e50a4d6c509eb10a86efa236a396ebcffa804d0e5cee08dcfR23-R42)

**Frontend: UI/UX Enhancement for Recommendations**
* Enhanced the recommended movies list so that posters and titles are clickable links to the corresponding TMDB page when a `tmdbId` is present. Improved the styling for these links and maintained accessibility for movies without a TMDB ID. [[1]](diffhunk://#diff-fc77d931f5bb3d05e97da5ea347365c7c84b909150a988cd87f780132e63e32bR284) [[2]](diffhunk://#diff-fc77d931f5bb3d05e97da5ea347365c7c84b909150a988cd87f780132e63e32bR293-R308) [[3]](diffhunk://#diff-1a9955d999f6b0cbc66f469db301e7efb1953556a6f69cf767d41db8ff44480fL212-R228)

Closes #28 #25 #26 #27 