### PR TITLE
Enhance config persistence and scan tracking features

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The app will be available at `http://localhost:4277`.
 docker pull primetime43/gaps-2:develop
 ```
 
-> **Heads up — config is machine-bound.** GAPS encrypts saved settings (API keys, tokens, server URLs) in `backend/data/config.enc` using a key derived from the host's MAC address and hostname. That means the file **cannot be moved between machines** and may become unreadable after a VM migration, a Docker network recreation that rotates the container's MAC, or migrating between NAS models. If that happens, delete `config.enc` and re-enter your settings from the UI. Nothing critical is stored there that can't be re-entered in a minute or two.
+> **Persist `/app/data`.** GAPS encrypts saved settings (API keys, tokens, server URLs) in `backend/data/config.enc`. The encryption key lives next to it as `.config.key`, so both files must be on a persistent volume — otherwise every container recreation generates a fresh key and the old config becomes unreadable. The `docker run` example above and the Compose file already mount `/app/data`; if you write your own command (e.g. an unRAID template), make sure the mount is there. To override the key explicitly — for moving between hosts or sharing a config across replicas — set the `GAPS2_CONFIG_KEY` environment variable to a Fernet key (output of `python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"`).
 
 ### Images of v2.1.0
 <details>

--- a/backend/app/blueprints/about.py
+++ b/backend/app/blueprints/about.py
@@ -4,7 +4,7 @@ from flask import Blueprint, jsonify
 
 about_bp = Blueprint('about', __name__)
 
-VERSION = '2.3.1'
+VERSION = '2.4.0'
 
 
 def _get_commit() -> str:

--- a/backend/app/blueprints/recommendations.py
+++ b/backend/app/blueprints/recommendations.py
@@ -120,6 +120,7 @@ def scan_library_gaps():
         owned_movies=owned_movies,
         owned_tmdb_ids=owned_ids,
         show_existing=show_existing,
+        library_names=names,
     )
 
     return jsonify(status='started', total=len(owned_movies))

--- a/backend/app/services/config_store.py
+++ b/backend/app/services/config_store.py
@@ -30,6 +30,16 @@ def _ensure_dir():
     os.makedirs(_DATA_DIR, exist_ok=True)
 
 
+def data_dir() -> str:
+    """Return the data directory path, creating it if needed.
+
+    Exposed for other services that need to persist sidecar files (e.g. a
+    plain-JSON cache) into the same directory that holds config.enc.
+    """
+    _ensure_dir()
+    return _DATA_DIR
+
+
 def _legacy_machine_key() -> bytes:
     """Pre-keyfile key derived from hostname + MAC.
 

--- a/backend/app/services/config_store.py
+++ b/backend/app/services/config_store.py
@@ -11,6 +11,8 @@ from cryptography.fernet import Fernet, InvalidToken
 
 logger = logging.getLogger(__name__)
 
+_KEY_ENV_VAR = 'GAPS2_CONFIG_KEY'
+
 
 def _get_base_dir():
     """Return the backend root, works both normally and in a PyInstaller bundle."""
@@ -21,13 +23,20 @@ def _get_base_dir():
 
 _DATA_DIR = os.path.join(_get_base_dir(), 'data')
 _CONFIG_FILE = os.path.join(_DATA_DIR, 'config.enc')
+_KEY_FILE = os.path.join(_DATA_DIR, '.config.key')
 
 
-def _get_machine_key() -> bytes:
-    """Derive a Fernet key from stable machine-specific identifiers.
+def _ensure_dir():
+    os.makedirs(_DATA_DIR, exist_ok=True)
 
-    Combines the OS node name and MAC address so the encrypted config
-    cannot be decrypted on a different machine.
+
+def _legacy_machine_key() -> bytes:
+    """Pre-keyfile key derived from hostname + MAC.
+
+    Kept only as a one-time migration fallback so installs that pre-date the
+    keyfile can still decrypt their existing config.enc. Container deployments
+    broke under this scheme because hostname and MAC change on every recreate
+    (issue #36), so new installs use a random keyfile instead.
     """
     node = platform.node()
     mac = hex(uuid.getnode())
@@ -36,11 +45,53 @@ def _get_machine_key() -> bytes:
     return base64.urlsafe_b64encode(digest[:32])
 
 
-def _ensure_dir():
-    os.makedirs(_DATA_DIR, exist_ok=True)
+def _load_keyfile():
+    if not os.path.isfile(_KEY_FILE):
+        return None
+    try:
+        with open(_KEY_FILE, 'rb') as f:
+            return f.read().strip()
+    except OSError as e:
+        logger.warning("Failed to read keyfile %s: %s", _KEY_FILE, e)
+        return None
 
 
-_fernet = Fernet(_get_machine_key())
+def _write_keyfile(key: bytes) -> None:
+    _ensure_dir()
+    with open(_KEY_FILE, 'wb') as f:
+        f.write(key)
+    try:
+        os.chmod(_KEY_FILE, 0o600)
+    except OSError:
+        # Windows chmod is best-effort; the key file still lives in a user-owned dir.
+        pass
+
+
+def _resolve_key():
+    """Return (active_fernet_key, allow_legacy_migration).
+
+    Resolution order:
+      1. GAPS2_CONFIG_KEY env var — explicit override for advanced deployments.
+      2. Existing keyfile at <data>/.config.key.
+      3. Generate a new random key and persist it.
+    """
+    env_key = os.environ.get(_KEY_ENV_VAR)
+    if env_key:
+        return env_key.encode(), True
+
+    existing = _load_keyfile()
+    if existing:
+        return existing, False
+
+    new_key = Fernet.generate_key()
+    _write_keyfile(new_key)
+    logger.info("Generated new config encryption key at %s", _KEY_FILE)
+    return new_key, True
+
+
+_active_key, _allow_legacy_migration = _resolve_key()
+_fernet = Fernet(_active_key)
+_legacy_fernet = Fernet(_legacy_machine_key())
 
 
 def load() -> dict:
@@ -50,11 +101,38 @@ def load() -> dict:
     try:
         with open(_CONFIG_FILE, 'rb') as f:
             encrypted = f.read()
-        decrypted = _fernet.decrypt(encrypted)
-        return json.loads(decrypted)
-    except (InvalidToken, json.JSONDecodeError, OSError) as e:
-        logger.warning("Failed to load config: %s", e)
+    except OSError as e:
+        logger.warning("Failed to read config file: %s", e)
         return {}
+
+    try:
+        return json.loads(_fernet.decrypt(encrypted))
+    except InvalidToken:
+        pass
+    except json.JSONDecodeError as e:
+        logger.warning("Failed to parse decrypted config: %s", e)
+        return {}
+
+    if _allow_legacy_migration:
+        try:
+            data = json.loads(_legacy_fernet.decrypt(encrypted))
+        except (InvalidToken, json.JSONDecodeError):
+            logger.warning(
+                "Could not decrypt %s with current or legacy key. "
+                "Delete the file and reconfigure from the UI if this is unexpected.",
+                _CONFIG_FILE,
+            )
+            return {}
+        logger.info("Migrated config.enc from legacy machine-bound key to keyfile.")
+        save(data)
+        return data
+
+    logger.warning(
+        "Could not decrypt %s with the configured key. "
+        "Delete the file and reconfigure from the UI if this is unexpected.",
+        _CONFIG_FILE,
+    )
+    return {}
 
 
 def save(data: dict) -> None:
@@ -66,8 +144,6 @@ def save(data: dict) -> None:
         f.write(encrypted)
     # Restrict to owner-only read/write so other users on a shared host
     # (or other containers on a shared volume) can't read the encrypted blob.
-    # Defense-in-depth: the contents are already Fernet-encrypted with a
-    # machine-bound key, so this guards against opportunistic copy-offs.
     try:
         os.chmod(_CONFIG_FILE, 0o600)
     except OSError:

--- a/backend/app/services/config_store.py
+++ b/backend/app/services/config_store.py
@@ -5,6 +5,7 @@ import logging
 import os
 import platform
 import sys
+import threading
 import uuid
 
 from cryptography.fernet import Fernet, InvalidToken
@@ -12,6 +13,11 @@ from cryptography.fernet import Fernet, InvalidToken
 logger = logging.getLogger(__name__)
 
 _KEY_ENV_VAR = 'GAPS2_CONFIG_KEY'
+
+# Serializes the read-modify-write in put/remove so concurrent writers
+# (request thread + scheduled-scan thread + scan-completion thread) can't
+# clobber each other's keys.
+_WRITE_LOCK = threading.Lock()
 
 
 def _get_base_dir():
@@ -146,19 +152,27 @@ def load() -> dict:
 
 
 def save(data: dict) -> None:
-    """Encrypt and save the full config dict to disk."""
+    """Encrypt and save the full config dict to disk via atomic rename.
+
+    The temp-file + os.replace dance means a concurrent reader either sees
+    the pre-save file or the post-save file, never a half-written blob.
+    """
     _ensure_dir()
     plaintext = json.dumps(data).encode()
     encrypted = _fernet.encrypt(plaintext)
-    with open(_CONFIG_FILE, 'wb') as f:
+    tmp = _CONFIG_FILE + '.tmp'
+    with open(tmp, 'wb') as f:
         f.write(encrypted)
     # Restrict to owner-only read/write so other users on a shared host
     # (or other containers on a shared volume) can't read the encrypted blob.
+    # Set on the temp file before the rename so the destination never exists
+    # with looser permissions.
     try:
-        os.chmod(_CONFIG_FILE, 0o600)
+        os.chmod(tmp, 0o600)
     except OSError:
         # Windows has a limited chmod; best-effort — encryption still protects contents.
         pass
+    os.replace(tmp, _CONFIG_FILE)
 
 
 def get(key: str, default=None):
@@ -166,12 +180,14 @@ def get(key: str, default=None):
 
 
 def put(key: str, value) -> None:
-    data = load()
-    data[key] = value
-    save(data)
+    with _WRITE_LOCK:
+        data = load()
+        data[key] = value
+        save(data)
 
 
 def remove(key: str) -> None:
-    data = load()
-    data.pop(key, None)
-    save(data)
+    with _WRITE_LOCK:
+        data = load()
+        data.pop(key, None)
+        save(data)

--- a/backend/app/services/schedule_service.py
+++ b/backend/app/services/schedule_service.py
@@ -1,10 +1,13 @@
 import logging
+from datetime import datetime, timezone
 
 from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.triggers.cron import CronTrigger
 from app.services import config_store
 
 logger = logging.getLogger(__name__)
+
+LAST_RUN_KEY = 'schedule_last_run'
 
 # Preset schedule options with cron expressions
 SCHEDULE_PRESETS = {
@@ -44,6 +47,7 @@ class ScheduleService:
         """Execute a scan using the saved library config."""
         if not self._app:
             logger.error("Scheduled scan skipped: app context not initialized")
+            self._record_last_run(status='skipped', library='', message='app context not initialized')
             return
 
         with self._app.app_context():
@@ -53,6 +57,7 @@ class ScheduleService:
                 source = config.get('source', 'plex')
                 if not library_name:
                     logger.warning("Scheduled scan skipped: no library configured")
+                    self._record_last_run(status='skipped', library='', message='no library configured')
                     return
 
                 logger.info("Scheduled scan started for library '%s' (source=%s)", library_name, source)
@@ -63,6 +68,9 @@ class ScheduleService:
                 api_key = tmdb.api_key
                 if not api_key:
                     logger.warning("Scheduled scan skipped: no TMDB API key configured")
+                    self._record_last_run(
+                        status='skipped', library=library_name, message='no TMDB API key configured'
+                    )
                     return
 
                 # Load movies if not cached
@@ -80,6 +88,11 @@ class ScheduleService:
                         "Scheduled scan skipped: library '%s' has no movies (server unreachable or library empty)",
                         library_name,
                     )
+                    self._record_last_run(
+                        status='skipped',
+                        library=library_name,
+                        message='library has no movies (server unreachable or library empty)',
+                    )
                     return
 
                 gaps, error = tmdb.find_collection_gaps(
@@ -90,6 +103,7 @@ class ScheduleService:
                 )
                 if error:
                     logger.error("Scheduled scan failed finding gaps for '%s': %s", library_name, error)
+                    self._record_last_run(status='error', library=library_name, message=str(error))
                     return
 
                 # Send notifications
@@ -99,11 +113,42 @@ class ScheduleService:
                     "Scheduled scan complete for '%s': %d missing across %d collections",
                     library_name, len(missing), collections,
                 )
+                self._record_last_run(
+                    status='success',
+                    library=library_name,
+                    missing=len(missing),
+                    collections=collections,
+                )
                 self._app.notification_service.notify_scan_results(
                     len(missing), collections, library_name
                 )
-            except Exception:
+            except Exception as e:
                 logger.exception("Scheduled scan crashed unexpectedly")
+                self._record_last_run(
+                    status='error',
+                    library=config_store.get('schedule', {}).get('library', ''),
+                    message=str(e),
+                )
+
+    @staticmethod
+    def _record_last_run(
+        status: str,
+        library: str,
+        missing: int = 0,
+        collections: int = 0,
+        message: str = '',
+    ) -> None:
+        try:
+            config_store.put(LAST_RUN_KEY, {
+                'timestamp': datetime.now(timezone.utc).isoformat(),
+                'status': status,
+                'library': library,
+                'missing': missing,
+                'collections': collections,
+                'message': message,
+            })
+        except OSError as e:
+            logger.warning("Failed to persist scheduled scan history: %s", e)
 
     def _add_job(self, preset: str) -> None:
         """Add or replace the scheduled job."""
@@ -146,5 +191,6 @@ class ScheduleService:
             'library': saved.get('library', ''),
             'source': saved.get('source', 'plex'),
             'next_run': str(job.next_run_time) if job else None,
+            'last_run': config_store.get(LAST_RUN_KEY),
             'presets': {k: v['label'] for k, v in SCHEDULE_PRESETS.items()},
         }

--- a/backend/app/services/tmdb_service.py
+++ b/backend/app/services/tmdb_service.py
@@ -35,6 +35,11 @@ class TmdbService:
         self._mc_cache_ts: dict[int, float] = {}
         self._coll_cache_ts: dict[int, float] = {}
         self._cache_file = os.path.join(config_store.data_dir(), _CACHE_FILE_NAME)
+        # _cache_lock protects in-memory dict reads/writes (held briefly).
+        # _cache_save_lock protects the file I/O on persist (held while writing
+        # the temp file). Separate so HTTP-driven dict updates don't block on
+        # the multi-MB JSON write to disk.
+        self._cache_lock = threading.Lock()
         self._cache_save_lock = threading.Lock()
         self._load_persistent_cache()
 
@@ -75,11 +80,12 @@ class TmdbService:
 
     def clear_cache(self) -> None:
         """Clear all TMDB response caches for a fresh scan."""
-        self._id_cache.clear()
-        self._movie_collection_cache.clear()
-        self._collection_cache.clear()
-        self._mc_cache_ts.clear()
-        self._coll_cache_ts.clear()
+        with self._cache_lock:
+            self._id_cache.clear()
+            self._movie_collection_cache.clear()
+            self._collection_cache.clear()
+            self._mc_cache_ts.clear()
+            self._coll_cache_ts.clear()
         try:
             os.remove(self._cache_file)
         except FileNotFoundError:
@@ -143,19 +149,30 @@ class TmdbService:
     def _save_persistent_cache(self) -> None:
         """Write the persistent caches to disk via atomic rename."""
         now = time.time()
+        # Snapshot under the cache lock so concurrent inserts can't corrupt
+        # the iteration. JSON serialization and file I/O happen outside the
+        # lock to keep contention with the HTTP-driven cache mutations short.
+        with self._cache_lock:
+            for key in self._movie_collection_cache:
+                self._mc_cache_ts.setdefault(key, now)
+            for key in self._collection_cache:
+                self._coll_cache_ts.setdefault(key, now)
+            mc_snapshot = list(self._movie_collection_cache.items())
+            coll_snapshot = list(self._collection_cache.items())
+            mc_ts = dict(self._mc_cache_ts)
+            coll_ts = dict(self._coll_cache_ts)
+
         payload: dict = {
             'version': 1,
-            'movie_collection': {},
-            'collections': {},
+            'movie_collection': {
+                str(key): {'value': value, 'at': mc_ts.get(key, now)}
+                for key, value in mc_snapshot
+            },
+            'collections': {
+                str(key): {'value': value, 'at': coll_ts.get(key, now)}
+                for key, value in coll_snapshot
+            },
         }
-        for key, value in self._movie_collection_cache.items():
-            ts = self._mc_cache_ts.get(key, now)
-            payload['movie_collection'][str(key)] = {'value': value, 'at': ts}
-            self._mc_cache_ts[key] = ts
-        for key, value in self._collection_cache.items():
-            ts = self._coll_cache_ts.get(key, now)
-            payload['collections'][str(key)] = {'value': value, 'at': ts}
-            self._coll_cache_ts[key] = ts
 
         with self._cache_save_lock:
             try:
@@ -194,8 +211,10 @@ class TmdbService:
         # 2. Try IMDB ID via /find endpoint (cached)
         if imdb_id:
             cache_key = f"imdb:{imdb_id}"
-            if cache_key in self._id_cache:
-                return self._id_cache[cache_key]
+            with self._cache_lock:
+                if cache_key in self._id_cache:
+                    return self._id_cache[cache_key]
+            resolved: int | None = None
             try:
                 resp = requests.get(
                     f"{self._base_url}/find/{imdb_id}",
@@ -206,17 +225,20 @@ class TmdbService:
                     results = resp.json().get("movie_results", [])
                     if results:
                         resolved = results[0]["id"]
-                        self._id_cache[cache_key] = resolved
-                        return resolved
             except Exception as e:
                 logger.warning("TMDB /find lookup failed for IMDB ID %s: %s", imdb_id, e)
-            self._id_cache[cache_key] = None
+            with self._cache_lock:
+                self._id_cache[cache_key] = resolved
+            if resolved is not None:
+                return resolved
 
         # 3. Try title + year search (cached)
         if title:
             cache_key = f"search:{title.lower()}|{year}"
-            if cache_key in self._id_cache:
-                return self._id_cache[cache_key]
+            with self._cache_lock:
+                if cache_key in self._id_cache:
+                    return self._id_cache[cache_key]
+            resolved = None
             try:
                 params = {"api_key": api_key, "query": title, "language": self._language}
                 if year:
@@ -236,42 +258,43 @@ class TmdbService:
                             if r.get("title", "").lower() == title.lower() and r_year == str(year):
                                 resolved = r["id"]
                                 break
-                        self._id_cache[cache_key] = resolved
-                        return resolved
             except Exception as e:
                 logger.warning("TMDB search failed for '%s' (%s): %s", title, year, e)
-            self._id_cache[cache_key] = None
+            with self._cache_lock:
+                self._id_cache[cache_key] = resolved
+            if resolved is not None:
+                return resolved
 
         return None
 
     def _get_collection_id(self, api_key: str, tmdb_id: int) -> int | None:
         """Get the collection ID for a movie, using cache."""
-        if tmdb_id in self._movie_collection_cache:
-            return self._movie_collection_cache[tmdb_id]
+        with self._cache_lock:
+            if tmdb_id in self._movie_collection_cache:
+                return self._movie_collection_cache[tmdb_id]
 
+        coll_id: int | None = None
         try:
             resp = requests.get(
                 f"{self._base_url}/movie/{tmdb_id}",
                 params={"api_key": api_key, "language": self._language},
                 timeout=10,
             )
-            if resp.status_code != 200:
-                self._movie_collection_cache[tmdb_id] = None
-                return None
-
-            collection = resp.json().get("belongs_to_collection")
-            coll_id = collection["id"] if collection else None
-            self._movie_collection_cache[tmdb_id] = coll_id
-            return coll_id
+            if resp.status_code == 200:
+                collection = resp.json().get("belongs_to_collection")
+                coll_id = collection["id"] if collection else None
         except Exception as e:
             logger.warning("Failed to get collection ID for TMDB %s: %s", tmdb_id, e)
-            self._movie_collection_cache[tmdb_id] = None
-            return None
+
+        with self._cache_lock:
+            self._movie_collection_cache[tmdb_id] = coll_id
+        return coll_id
 
     def _get_collection(self, api_key: str, collection_id: int) -> dict | None:
         """Fetch full collection data, using cache."""
-        if collection_id in self._collection_cache:
-            return self._collection_cache[collection_id]
+        with self._cache_lock:
+            if collection_id in self._collection_cache:
+                return self._collection_cache[collection_id]
 
         try:
             resp = requests.get(
@@ -281,13 +304,14 @@ class TmdbService:
             )
             if resp.status_code != 200:
                 return None
-
             data = resp.json()
-            self._collection_cache[collection_id] = data
-            return data
         except Exception as e:
             logger.warning("Failed to fetch collection %s: %s", collection_id, e)
             return None
+
+        with self._cache_lock:
+            self._collection_cache[collection_id] = data
+        return data
 
     def _build_gap_entries(
         self,

--- a/backend/app/services/tmdb_service.py
+++ b/backend/app/services/tmdb_service.py
@@ -59,6 +59,7 @@ class TmdbService:
             'collections_found': 0,
             'gaps': [],
             'total_owned': 0,
+            'libraries': [],
             'completed_at': None,
             'error': None,
         }
@@ -67,6 +68,7 @@ class TmdbService:
             progress['status'] = 'done'
             progress['gaps'] = last.get('gaps', [])
             progress['total_owned'] = last.get('total_owned', 0)
+            progress['libraries'] = last.get('libraries', [])
             progress['completed_at'] = last.get('completed_at')
         return progress
 
@@ -352,8 +354,10 @@ class TmdbService:
         owned_movies: list[dict],
         owned_tmdb_ids: set[int],
         show_existing: bool = False,
+        library_names: list[str] | None = None,
     ) -> None:
         """Start a library scan in a background thread."""
+        libraries = list(library_names or [])
         with self._scan_progress_lock:
             if self._scan_progress['status'] == 'scanning':
                 return  # Already running
@@ -365,13 +369,14 @@ class TmdbService:
                 'collections_found': 0,
                 'gaps': [],
                 'total_owned': len(owned_tmdb_ids),
+                'libraries': libraries,
                 'completed_at': None,
                 'error': None,
             }
 
         thread = threading.Thread(
             target=self._run_scan,
-            args=(api_key, owned_movies, owned_tmdb_ids, show_existing),
+            args=(api_key, owned_movies, owned_tmdb_ids, show_existing, libraries),
             daemon=True,
         )
         thread.start()
@@ -382,6 +387,7 @@ class TmdbService:
         owned_movies: list[dict],
         owned_tmdb_ids: set[int],
         show_existing: bool,
+        libraries: list[str],
     ) -> None:
         """Background scan worker."""
         try:
@@ -397,6 +403,7 @@ class TmdbService:
                 config_store.put('last_scan', {
                     'gaps': final_gaps,
                     'total_owned': len(owned_tmdb_ids),
+                    'libraries': libraries,
                     'completed_at': completed_at,
                 })
             except OSError as e:

--- a/backend/app/services/tmdb_service.py
+++ b/backend/app/services/tmdb_service.py
@@ -1,5 +1,6 @@
 import logging
 import threading
+from datetime import datetime, timezone
 import requests
 from app.services import config_store
 
@@ -18,9 +19,15 @@ class TmdbService:
         self._movie_collection_cache: dict[int, int | None] = {}
         self._collection_cache: dict[int, dict] = {}
 
-        # Scan progress tracking (shared between request thread and scan thread)
+        # Scan progress tracking (shared between request thread and scan thread).
+        # Seeded from the last persisted scan so the "Last Scan" card and gaps
+        # list survive a backend restart.
         self._scan_progress_lock = threading.Lock()
-        self._scan_progress: dict = {
+        self._scan_progress: dict = self._initial_scan_progress()
+
+    @staticmethod
+    def _initial_scan_progress() -> dict:
+        progress = {
             'status': 'idle',    # idle | scanning | done | error
             'processed': 0,
             'total': 0,
@@ -28,8 +35,16 @@ class TmdbService:
             'collections_found': 0,
             'gaps': [],
             'total_owned': 0,
+            'completed_at': None,
             'error': None,
         }
+        last = config_store.get('last_scan')
+        if last:
+            progress['status'] = 'done'
+            progress['gaps'] = last.get('gaps', [])
+            progress['total_owned'] = last.get('total_owned', 0)
+            progress['completed_at'] = last.get('completed_at')
+        return progress
 
     @property
     def api_key(self) -> str | None:
@@ -220,6 +235,7 @@ class TmdbService:
                 'collections_found': 0,
                 'gaps': [],
                 'total_owned': len(owned_tmdb_ids),
+                'completed_at': None,
                 'error': None,
             }
 
@@ -240,10 +256,21 @@ class TmdbService:
         """Background scan worker."""
         try:
             gaps, _ = self.find_collection_gaps(api_key, owned_movies, owned_tmdb_ids, show_existing)
+            completed_at = datetime.now(timezone.utc).isoformat()
+            final_gaps = gaps or []
             with self._scan_progress_lock:
-                self._scan_progress['gaps'] = gaps or []
+                self._scan_progress['gaps'] = final_gaps
                 self._scan_progress['total_owned'] = len(owned_tmdb_ids)
+                self._scan_progress['completed_at'] = completed_at
                 self._scan_progress['status'] = 'done'
+            try:
+                config_store.put('last_scan', {
+                    'gaps': final_gaps,
+                    'total_owned': len(owned_tmdb_ids),
+                    'completed_at': completed_at,
+                })
+            except OSError as e:
+                logger.warning("Failed to persist last_scan: %s", e)
         except Exception as e:
             with self._scan_progress_lock:
                 self._scan_progress['error'] = str(e)

--- a/backend/app/services/tmdb_service.py
+++ b/backend/app/services/tmdb_service.py
@@ -1,10 +1,19 @@
+import json
 import logging
+import os
 import threading
+import time
 from datetime import datetime, timezone
 import requests
 from app.services import config_store
 
 logger = logging.getLogger(__name__)
+
+_CACHE_FILE_NAME = 'tmdb_cache.json'
+# Collection memberships rarely change but new movies can be added to existing
+# collections (sequels, reissues), so re-fetch weekly to balance freshness vs.
+# TMDB rate limits.
+_CACHE_TTL_SECONDS = 7 * 24 * 60 * 60
 
 
 class TmdbService:
@@ -18,6 +27,16 @@ class TmdbService:
         self._id_cache: dict[str, int | None] = {}
         self._movie_collection_cache: dict[int, int | None] = {}
         self._collection_cache: dict[int, dict] = {}
+
+        # Persistent cache for the collection lookups (the expensive ones).
+        # _id_cache is intentionally not persisted — its search-key entries are
+        # cheap to regenerate and least stable. Per-entry timestamps live in
+        # parallel dicts so the in-memory cache shape stays unchanged.
+        self._mc_cache_ts: dict[int, float] = {}
+        self._coll_cache_ts: dict[int, float] = {}
+        self._cache_file = os.path.join(config_store.data_dir(), _CACHE_FILE_NAME)
+        self._cache_save_lock = threading.Lock()
+        self._load_persistent_cache()
 
         # Scan progress tracking (shared between request thread and scan thread).
         # Seeded from the last persisted scan so the "Last Scan" card and gaps
@@ -59,6 +78,93 @@ class TmdbService:
         self._id_cache.clear()
         self._movie_collection_cache.clear()
         self._collection_cache.clear()
+        self._mc_cache_ts.clear()
+        self._coll_cache_ts.clear()
+        try:
+            os.remove(self._cache_file)
+        except FileNotFoundError:
+            pass
+        except OSError as e:
+            logger.warning("Failed to remove TMDB cache file: %s", e)
+
+    def _load_persistent_cache(self) -> None:
+        """Populate in-memory caches from disk, dropping entries older than the TTL."""
+        if not os.path.isfile(self._cache_file):
+            return
+        try:
+            with open(self._cache_file, 'r') as f:
+                data = json.load(f)
+        except (OSError, json.JSONDecodeError) as e:
+            logger.warning("Failed to load TMDB cache from %s: %s", self._cache_file, e)
+            return
+        if not isinstance(data, dict):
+            return
+
+        now = time.time()
+        for raw_key, entry in (data.get('movie_collection') or {}).items():
+            if not isinstance(entry, dict):
+                continue
+            ts = entry.get('at')
+            if not isinstance(ts, (int, float)) or now - ts > _CACHE_TTL_SECONDS:
+                continue
+            try:
+                key = int(raw_key)
+            except (TypeError, ValueError):
+                continue
+            value = entry.get('value')
+            if value is not None and not isinstance(value, int):
+                continue
+            self._movie_collection_cache[key] = value
+            self._mc_cache_ts[key] = ts
+
+        for raw_key, entry in (data.get('collections') or {}).items():
+            if not isinstance(entry, dict):
+                continue
+            ts = entry.get('at')
+            if not isinstance(ts, (int, float)) or now - ts > _CACHE_TTL_SECONDS:
+                continue
+            try:
+                key = int(raw_key)
+            except (TypeError, ValueError):
+                continue
+            value = entry.get('value')
+            if not isinstance(value, dict):
+                continue
+            self._collection_cache[key] = value
+            self._coll_cache_ts[key] = ts
+
+        if self._movie_collection_cache or self._collection_cache:
+            logger.info(
+                "Loaded TMDB cache: %d collection memberships, %d collections",
+                len(self._movie_collection_cache),
+                len(self._collection_cache),
+            )
+
+    def _save_persistent_cache(self) -> None:
+        """Write the persistent caches to disk via atomic rename."""
+        now = time.time()
+        payload: dict = {
+            'version': 1,
+            'movie_collection': {},
+            'collections': {},
+        }
+        for key, value in self._movie_collection_cache.items():
+            ts = self._mc_cache_ts.get(key, now)
+            payload['movie_collection'][str(key)] = {'value': value, 'at': ts}
+            self._mc_cache_ts[key] = ts
+        for key, value in self._collection_cache.items():
+            ts = self._coll_cache_ts.get(key, now)
+            payload['collections'][str(key)] = {'value': value, 'at': ts}
+            self._coll_cache_ts[key] = ts
+
+        with self._cache_save_lock:
+            try:
+                tmp = self._cache_file + '.tmp'
+                with open(tmp, 'w') as f:
+                    json.dump(payload, f)
+                os.replace(tmp, self._cache_file)
+            except OSError as e:
+                logger.warning("Failed to persist TMDB cache: %s", e)
 
     def test_api_key(self, api_key: str) -> tuple[bool, int]:
         url = f"{self._base_url}/configuration?api_key={api_key}"
@@ -325,6 +431,7 @@ class TmdbService:
             gaps.extend(self._build_gap_entries(coll_data, owned_tmdb_ids, show_existing))
 
         gaps.sort(key=lambda g: (g["collectionName"], g["year"]))
+        self._save_persistent_cache()
         return gaps, None
 
     def find_gaps_for_movie(

--- a/frontend/src/app/components/recommended/recommended.component.spec.ts
+++ b/frontend/src/app/components/recommended/recommended.component.spec.ts
@@ -63,6 +63,7 @@ describe('RecommendedComponent', () => {
       collections_found: 0,
       gaps: [],
       total_owned: 0,
+      libraries: [],
       completed_at: null,
       error: null,
     }));

--- a/frontend/src/app/components/recommended/recommended.component.spec.ts
+++ b/frontend/src/app/components/recommended/recommended.component.spec.ts
@@ -55,6 +55,17 @@ describe('RecommendedComponent', () => {
     jellyfinService.getActiveServer.and.returnValue(of({} as any));
     embyService.getActiveServer.and.returnValue(of({} as any));
     recommendationService.getIgnored.and.returnValue(of([]));
+    recommendationService.getScanProgress.and.returnValue(of({
+      status: 'idle',
+      processed: 0,
+      total: 0,
+      current_movie: '',
+      collections_found: 0,
+      gaps: [],
+      total_owned: 0,
+      completed_at: null,
+      error: null,
+    }));
     preferencesService.load.and.returnValue(of({
       defaultLibrary: '',
       moviesPerPage: 50,

--- a/frontend/src/app/components/recommended/recommended.component.ts
+++ b/frontend/src/app/components/recommended/recommended.component.ts
@@ -178,24 +178,29 @@ export class RecommendedComponent implements OnInit, OnDestroy {
       return;
     }
 
+    // Re-entry: the component preserves its state across navigation, so the
+    // user's in-memory selection and gaps are the source of truth. Don't
+    // re-hydrate from the persisted scan — it may be stale relative to a
+    // library change the user made before navigating away (issue #36).
+    if (!autoSelectLibrary) {
+      this.loading = false;
+      return;
+    }
+
     this.recommendationService.getScanProgress().pipe(
       catchError(() => of(null))
     ).subscribe((progress) => {
       const validScan = !!(progress && progress.status === 'done' && progress.gaps?.length);
       const scanLibs = validScan ? (progress!.libraries || []) : [];
 
-      // On first load, the scan's libraries take precedence over the user's
-      // default — otherwise the dropdown and the gaps panel show different
-      // libraries (issue #36). On re-entry (autoSelectLibrary=false) we leave
-      // the existing selection alone.
-      if (autoSelectLibrary) {
-        if (scanLibs.length && this.libraries.some(l => scanLibs.includes(l.title))) {
-          this.selectedLibrary = scanLibs[0];
-          this.selectedLibraries = [...scanLibs];
-          this.onLibrarySelect();
-        } else {
-          this.applyDefaultLibrary(prefs);
-        }
+      // The scan's libraries take precedence over the user's default so the
+      // dropdown matches the gaps that are about to render.
+      if (scanLibs.length && this.libraries.some(l => scanLibs.includes(l.title))) {
+        this.selectedLibrary = scanLibs[0];
+        this.selectedLibraries = [...scanLibs];
+        this.onLibrarySelect();
+      } else {
+        this.applyDefaultLibrary(prefs);
       }
 
       if (validScan) {

--- a/frontend/src/app/components/recommended/recommended.component.ts
+++ b/frontend/src/app/components/recommended/recommended.component.ts
@@ -82,6 +82,9 @@ export class RecommendedComponent implements OnInit, OnDestroy {
   scanProgress: ScanProgress | null = null;
   freshScanActive = false;
   showFreshScanConfirm = false;
+  // Cached snapshot of the last completed scan so toggling library selection
+  // back to a previously-scanned library restores its gaps without re-running.
+  private lastCompletedScan: { libraries: string[]; gaps: CollectionGap[]; totalOwned: number } | null = null;
   private pollSub: Subscription | null = null;
   private destroy$ = new Subject<void>();
 
@@ -208,6 +211,11 @@ export class RecommendedComponent implements OnInit, OnDestroy {
         this.totalOwned = progress!.total_owned;
         this.scanMode = true;
         this.applyFilter();
+        this.lastCompletedScan = {
+          libraries: scanLibs,
+          gaps: progress!.gaps,
+          totalOwned: progress!.total_owned,
+        };
       }
       this.loading = false;
     });
@@ -227,7 +235,6 @@ export class RecommendedComponent implements OnInit, OnDestroy {
     if (!this.selectedLibraries.includes(this.selectedLibrary)) {
       this.selectedLibraries = [this.selectedLibrary];
     }
-    this.loadingMovies = true;
     this.movies = [];
     this.movieFilter = '';
     this.allGaps = [];
@@ -236,6 +243,15 @@ export class RecommendedComponent implements OnInit, OnDestroy {
     this.scanMode = false;
     this.errorMessage = '';
 
+    // If the cached last scan matches this selection exactly, restore its
+    // gaps so users don't have to re-scan just to view results they already
+    // have. Otherwise stay in browse mode.
+    this.tryRestoreScanForCurrentSelection();
+
+    // Always load movies so "Scan for Gaps" can run without a re-fetch. When
+    // a scan was restored we hide the spinner since the user is now looking
+    // at the gaps panel, not the movie picker.
+    this.loadingMovies = !this.scanMode;
     this.libraryService.getMovies(this.selectedLibrary, this.activeSource).subscribe({
       next: (res: any) => {
         if (res.error) {
@@ -252,6 +268,21 @@ export class RecommendedComponent implements OnInit, OnDestroy {
         this.loadingMovies = false;
       }
     });
+  }
+
+  private tryRestoreScanForCurrentSelection(): void {
+    const cached = this.lastCompletedScan;
+    if (!cached?.gaps?.length || !cached.libraries.length) return;
+    // Order-independent set equality between the cached scan's libraries and
+    // the user's current selection. Partial matches don't qualify — a single
+    // library shouldn't surface the gaps from a combined multi-library scan.
+    const cur = [...this.selectedLibraries].sort().join('|');
+    const scan = [...cached.libraries].sort().join('|');
+    if (cur !== scan) return;
+    this.allGaps = cached.gaps;
+    this.totalOwned = cached.totalOwned;
+    this.scanMode = true;
+    this.applyFilter();
   }
 
   toggleLibrarySelection(libTitle: string): void {
@@ -336,6 +367,11 @@ export class RecommendedComponent implements OnInit, OnDestroy {
             this.applyFilter();
             this.loadingGaps = false;
             this.scanProgress = null;
+            this.lastCompletedScan = {
+              libraries: progress.libraries?.length ? progress.libraries : [...this.selectedLibraries],
+              gaps: progress.gaps,
+              totalOwned: progress.total_owned,
+            };
           } else if (progress.status === 'error') {
             this.stopPolling();
             this.errorMessage = progress.error || 'Scan failed.';

--- a/frontend/src/app/components/recommended/recommended.component.ts
+++ b/frontend/src/app/components/recommended/recommended.component.ts
@@ -82,9 +82,10 @@ export class RecommendedComponent implements OnInit, OnDestroy {
   scanProgress: ScanProgress | null = null;
   freshScanActive = false;
   showFreshScanConfirm = false;
-  // Cached snapshot of the last completed scan so toggling library selection
-  // back to a previously-scanned library restores its gaps without re-running.
-  private lastCompletedScan: { libraries: string[]; gaps: CollectionGap[]; totalOwned: number } | null = null;
+  // Cache of completed scans keyed by sorted-library combination, so toggling
+  // library selection back to any previously-scanned set restores its gaps
+  // without re-running. In-memory only; backend persists just the most recent.
+  private completedScans = new Map<string, { gaps: CollectionGap[]; totalOwned: number }>();
   private pollSub: Subscription | null = null;
   private destroy$ = new Subject<void>();
 
@@ -211,11 +212,7 @@ export class RecommendedComponent implements OnInit, OnDestroy {
         this.totalOwned = progress!.total_owned;
         this.scanMode = true;
         this.applyFilter();
-        this.lastCompletedScan = {
-          libraries: scanLibs,
-          gaps: progress!.gaps,
-          totalOwned: progress!.total_owned,
-        };
+        this.cacheCompletedScan(scanLibs, progress!.gaps, progress!.total_owned);
       }
       this.loading = false;
     });
@@ -271,18 +268,27 @@ export class RecommendedComponent implements OnInit, OnDestroy {
   }
 
   private tryRestoreScanForCurrentSelection(): void {
-    const cached = this.lastCompletedScan;
-    if (!cached?.gaps?.length || !cached.libraries.length) return;
-    // Order-independent set equality between the cached scan's libraries and
-    // the user's current selection. Partial matches don't qualify — a single
-    // library shouldn't surface the gaps from a combined multi-library scan.
-    const cur = [...this.selectedLibraries].sort().join('|');
-    const scan = [...cached.libraries].sort().join('|');
-    if (cur !== scan) return;
+    const key = this.scanKey(this.selectedLibraries);
+    if (!key) return;
+    const cached = this.completedScans.get(key);
+    if (!cached?.gaps?.length) return;
     this.allGaps = cached.gaps;
     this.totalOwned = cached.totalOwned;
     this.scanMode = true;
     this.applyFilter();
+  }
+
+  private cacheCompletedScan(libraries: string[], gaps: CollectionGap[], totalOwned: number): void {
+    const key = this.scanKey(libraries);
+    if (!key) return;
+    this.completedScans.set(key, { gaps, totalOwned });
+  }
+
+  private scanKey(libraries: string[]): string {
+    if (!libraries?.length) return '';
+    // Order-independent identifier for a library set. Partial overlaps don't
+    // qualify — a single-library selection won't restore a multi-library scan.
+    return [...libraries].sort().join('|');
   }
 
   toggleLibrarySelection(libTitle: string): void {
@@ -367,11 +373,8 @@ export class RecommendedComponent implements OnInit, OnDestroy {
             this.applyFilter();
             this.loadingGaps = false;
             this.scanProgress = null;
-            this.lastCompletedScan = {
-              libraries: progress.libraries?.length ? progress.libraries : [...this.selectedLibraries],
-              gaps: progress.gaps,
-              totalOwned: progress.total_owned,
-            };
+            const scanLibs = progress.libraries?.length ? progress.libraries : [...this.selectedLibraries];
+            this.cacheCompletedScan(scanLibs, progress.gaps, progress.total_owned);
           } else if (progress.status === 'error') {
             this.stopPolling();
             this.errorMessage = progress.error || 'Scan failed.';

--- a/frontend/src/app/components/recommended/recommended.component.ts
+++ b/frontend/src/app/components/recommended/recommended.component.ts
@@ -172,6 +172,24 @@ export class RecommendedComponent implements OnInit, OnDestroy {
         this.libraries = [];
       }
       this.loading = false;
+      this.hydrateLastScan();
+    });
+  }
+
+  private hydrateLastScan(): void {
+    // Restore the gaps panel from the last persisted scan so users don't have
+    // to re-run the scan after a backend restart. Skipped while a scan is
+    // already in progress in this session, and after the user has drilled into
+    // a single-movie view.
+    if (this.scanProgress || this.selectedMovie) return;
+    this.recommendationService.getScanProgress().pipe(
+      catchError(() => of(null))
+    ).subscribe((progress) => {
+      if (!progress || progress.status !== 'done' || !progress.gaps?.length) return;
+      this.allGaps = progress.gaps;
+      this.totalOwned = progress.total_owned;
+      this.scanMode = true;
+      this.applyFilter();
     });
   }
 

--- a/frontend/src/app/components/recommended/recommended.component.ts
+++ b/frontend/src/app/components/recommended/recommended.component.ts
@@ -160,37 +160,60 @@ export class RecommendedComponent implements OnInit, OnDestroy {
         this.libraries = Array.isArray(res.libraries)
           ? res.libraries.filter((lib: MediaLibrary) => lib.type === 'movie')
           : [];
-
-        if (autoSelectLibrary && prefs?.defaultLibrary && this.libraries.some(l => l.title === prefs.defaultLibrary)) {
-          this.selectedLibrary = prefs.defaultLibrary;
-          this.selectedLibraries = [prefs.defaultLibrary];
-          this.onLibrarySelect();
-        }
+        this.finishInitialization(prefs, autoSelectLibrary);
       } else {
         this.hasServer = false;
         this.activeServerName = '';
         this.libraries = [];
+        this.loading = false;
       }
-      this.loading = false;
-      this.hydrateLastScan();
     });
   }
 
-  private hydrateLastScan(): void {
-    // Restore the gaps panel from the last persisted scan so users don't have
-    // to re-run the scan after a backend restart. Skipped while a scan is
-    // already in progress in this session, and after the user has drilled into
-    // a single-movie view.
-    if (this.scanProgress || this.selectedMovie) return;
+  private finishInitialization(prefs: any, autoSelectLibrary: boolean): void {
+    // Skip restore if the user is mid-scan or drilled into a single movie.
+    if (this.scanProgress || this.selectedMovie) {
+      if (autoSelectLibrary) this.applyDefaultLibrary(prefs);
+      this.loading = false;
+      return;
+    }
+
     this.recommendationService.getScanProgress().pipe(
       catchError(() => of(null))
     ).subscribe((progress) => {
-      if (!progress || progress.status !== 'done' || !progress.gaps?.length) return;
-      this.allGaps = progress.gaps;
-      this.totalOwned = progress.total_owned;
-      this.scanMode = true;
-      this.applyFilter();
+      const validScan = !!(progress && progress.status === 'done' && progress.gaps?.length);
+      const scanLibs = validScan ? (progress!.libraries || []) : [];
+
+      // On first load, the scan's libraries take precedence over the user's
+      // default — otherwise the dropdown and the gaps panel show different
+      // libraries (issue #36). On re-entry (autoSelectLibrary=false) we leave
+      // the existing selection alone.
+      if (autoSelectLibrary) {
+        if (scanLibs.length && this.libraries.some(l => scanLibs.includes(l.title))) {
+          this.selectedLibrary = scanLibs[0];
+          this.selectedLibraries = [...scanLibs];
+          this.onLibrarySelect();
+        } else {
+          this.applyDefaultLibrary(prefs);
+        }
+      }
+
+      if (validScan) {
+        this.allGaps = progress!.gaps;
+        this.totalOwned = progress!.total_owned;
+        this.scanMode = true;
+        this.applyFilter();
+      }
+      this.loading = false;
     });
+  }
+
+  private applyDefaultLibrary(prefs: any): void {
+    if (prefs?.defaultLibrary && this.libraries.some(l => l.title === prefs.defaultLibrary)) {
+      this.selectedLibrary = prefs.defaultLibrary;
+      this.selectedLibraries = [prefs.defaultLibrary];
+      this.onLibrarySelect();
+    }
   }
 
   onLibrarySelect(): void {

--- a/frontend/src/app/components/settings/schedule-settings/schedule-settings.component.html
+++ b/frontend/src/app/components/settings/schedule-settings/schedule-settings.component.html
@@ -20,6 +20,20 @@
       Next scan: {{ schedule.next_run }}
     </div>
 
+    <div *ngIf="schedule?.last_run as last" class="text-muted mb-3" style="font-size: 13px;">
+      <div *ngIf="last.status === 'success'">
+        Last scheduled scan: {{ last.timestamp | date:'medium' }} — found
+        <strong>{{ last.missing }}</strong> missing across <strong>{{ last.collections }}</strong>
+        collection(s) in "{{ last.library }}".
+      </div>
+      <div *ngIf="last.status === 'skipped'">
+        Last scheduled scan: {{ last.timestamp | date:'medium' }} — skipped ({{ last.message }}).
+      </div>
+      <div *ngIf="last.status === 'error'">
+        Last scheduled scan: {{ last.timestamp | date:'medium' }} — failed ({{ last.message }}).
+      </div>
+    </div>
+
     <!-- Message -->
     <div *ngIf="message"
          class="alert"

--- a/frontend/src/app/index/index.component.html
+++ b/frontend/src/app/index/index.component.html
@@ -55,6 +55,18 @@
           <p *ngIf="scheduleEnabled">
             {{ schedulePreset }} &mdash; Next run: {{ nextRun || 'N/A' }}
           </p>
+          <p *ngIf="scheduleEnabled && scheduleLastRun" class="text-muted mb-0" style="font-size: 13px;">
+            <ng-container *ngIf="scheduleLastRun.status === 'success'">
+              Last run: {{ scheduleLastRun.timestamp | date:'short' }} &mdash; found
+              <strong>{{ scheduleLastRun.missing }}</strong> missing.
+            </ng-container>
+            <ng-container *ngIf="scheduleLastRun.status === 'skipped'">
+              Last run: {{ scheduleLastRun.timestamp | date:'short' }} &mdash; skipped.
+            </ng-container>
+            <ng-container *ngIf="scheduleLastRun.status === 'error'">
+              Last run: {{ scheduleLastRun.timestamp | date:'short' }} &mdash; failed.
+            </ng-container>
+          </p>
           <p *ngIf="!scheduleEnabled">
             No schedule set.
             <a [routerLink]="['/settings/schedule']" class="activeLink">Configure now</a>

--- a/frontend/src/app/index/index.component.spec.ts
+++ b/frontend/src/app/index/index.component.spec.ts
@@ -43,7 +43,7 @@ describe('IndexComponent', () => {
     httpMock.expectOne(`${environment.apiUrl}/emby/active-server`)
       .flush(options?.emby ?? {});
     httpMock.expectOne(`${environment.apiUrl}/schedule`)
-      .flush(options?.schedule ?? { enabled: false, preset: '', next_run: null, presets: {} });
+      .flush(options?.schedule ?? { enabled: false, preset: '', next_run: null, last_run: null, presets: {} });
     httpMock.expectOne(`${environment.apiUrl}/recommendations/scan/progress`)
       .flush(options?.progress ?? { status: 'idle' });
   }
@@ -120,7 +120,7 @@ describe('IndexComponent', () => {
 
   it('should load schedule status', fakeAsync(() => {
     flushInitRequests({
-      schedule: { enabled: true, preset: 'daily', next_run: '2026-04-07T00:00:00Z', presets: {} },
+      schedule: { enabled: true, preset: 'daily', next_run: '2026-04-07T00:00:00Z', last_run: null, presets: {} },
     });
     tick();
 

--- a/frontend/src/app/index/index.component.ts
+++ b/frontend/src/app/index/index.component.ts
@@ -5,7 +5,7 @@ import { TmdbService } from '../services/tmdb/tmdb.service';
 import { PlexService } from '../services/plex.service';
 import { JellyfinService } from '../services/jellyfin.service';
 import { EmbyService } from '../services/emby.service';
-import { ScheduleService, ScheduleConfig } from '../services/schedule.service';
+import { ScheduleService, ScheduleConfig, ScheduleLastRun } from '../services/schedule.service';
 import { HttpClient } from '@angular/common/http';
 import { environment } from '../../environments/environment';
 
@@ -25,6 +25,7 @@ export class IndexComponent implements OnInit {
   scheduleEnabled = false;
   schedulePreset = '';
   nextRun: string | null = null;
+  scheduleLastRun: ScheduleLastRun | null = null;
 
   lastScanStatus = '';
   lastScanGaps = 0;
@@ -71,6 +72,7 @@ export class IndexComponent implements OnInit {
         this.scheduleEnabled = config.enabled;
         this.schedulePreset = config.preset;
         this.nextRun = config.next_run;
+        this.scheduleLastRun = config.last_run;
       },
       error: () => {}
     });

--- a/frontend/src/app/services/recommendation.service.ts
+++ b/frontend/src/app/services/recommendation.service.ts
@@ -14,6 +14,7 @@ export interface ScanProgress {
   collections_found: number;
   gaps: CollectionGap[];
   total_owned: number;
+  completed_at: string | null;
   error: string | null;
 }
 

--- a/frontend/src/app/services/recommendation.service.ts
+++ b/frontend/src/app/services/recommendation.service.ts
@@ -14,6 +14,7 @@ export interface ScanProgress {
   collections_found: number;
   gaps: CollectionGap[];
   total_owned: number;
+  libraries: string[];
   completed_at: string | null;
   error: string | null;
 }

--- a/frontend/src/app/services/schedule.service.ts
+++ b/frontend/src/app/services/schedule.service.ts
@@ -3,12 +3,22 @@ import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { environment } from '../../environments/environment';
 
+export interface ScheduleLastRun {
+  timestamp: string;
+  status: 'success' | 'skipped' | 'error';
+  library: string;
+  missing: number;
+  collections: number;
+  message: string;
+}
+
 export interface ScheduleConfig {
   enabled: boolean;
   preset: string;
   library: string;
   source: string;
   next_run: string | null;
+  last_run: ScheduleLastRun | null;
   presets: { [key: string]: string };
 }
 

--- a/frontend/src/environments/environment.prod.ts
+++ b/frontend/src/environments/environment.prod.ts
@@ -1,5 +1,5 @@
 export const environment = {
   production: true,
   apiUrl: '/api',
-  version: '2.3.0'
+  version: '2.3.1'
 };

--- a/frontend/src/environments/environment.prod.ts
+++ b/frontend/src/environments/environment.prod.ts
@@ -1,5 +1,5 @@
 export const environment = {
   production: true,
   apiUrl: '/api',
-  version: '2.3.1'
+  version: '2.4.0'
 };

--- a/frontend/src/environments/environment.ts
+++ b/frontend/src/environments/environment.ts
@@ -1,5 +1,5 @@
 export const environment = {
   production: false,
   apiUrl: '/api',
-  version: '2.3.0'
+  version: '2.3.1'
 };

--- a/frontend/src/environments/environment.ts
+++ b/frontend/src/environments/environment.ts
@@ -1,5 +1,5 @@
 export const environment = {
   production: false,
   apiUrl: '/api',
-  version: '2.3.1'
+  version: '2.4.0'
 };


### PR DESCRIPTION
## Fixed

- **Config encryption key no longer tied to container identity**
([#36](https://github.com/primetime43/GAPS-2/issues/36)) — replaced the hostname+MAC-derived key with a
random Fernet key persisted as `data/.config.key`, with `GAPS2_CONFIG_KEY` env var override. Existing
bare-metal/PyInstaller installs migrate transparently via a one-time legacy-key decrypt-and-rewrite.
- **`config_store.put` and `remove` are now thread-safe** — added a module-level write lock so concurrent
writers (scheduled scan thread, scan-completion thread, request thread) can no longer clobber each other
via lost read-modify-write races.
- **`config_store.save` uses atomic temp-file + `os.replace`** so a concurrent reader never observes a
torn write.
- **TMDB cache mutations now hold a lock** — `resolve_tmdb_id`, `_get_collection_id`, `_get_collection`,
`clear_cache`, and `_save_persistent_cache` synchronize via a dedicated `_cache_lock`. The real bug here
was `_save_persistent_cache` iterating dicts that a concurrent request was inserting into, which would
raise `RuntimeError: dictionary changed size during iteration` under load.
- **/recommended page bugs** caught while testing:
- "Last Scan" card and the gaps list now survive backend restarts instead of resetting to idle until the
next scan.
- Library dropdown is synced with the displayed scan results on first load — previously the dropdown
showed the user's default library while the gaps panel showed whatever the last scan was for.
- On re-entry from another route, the component's in-memory state is preserved instead of getting
overwritten by a stale persisted scan.
- Toggling the dropdown back to a previously-scanned library restores its cached gaps instead of forcing
a re-scan.
- Cache now holds one scan per library combination, so scanning Library 1 then Library 2 keeps both
around and the dropdown can flip between them freely.

## Added

- **Last scan persistence** — completed scans (gaps, total owned, completed-at, library set) are saved to
`config_store` under `last_scan` and rehydrated on `TmdbService.__init__`. The dashboard's "Last Scan"
card and `/recommended`'s gaps view both come back automatically after a backend restart.
- **Scheduled-scan history** — every scheduled scan attempt (success, skip, or error) writes a
`schedule_last_run` record. The schedule settings page renders a verbose status line including the
skip/error reason; the dashboard's "Scheduled Scans" card shows a terse "Last run: … — found N missing"
follow-up. Stored separately from the schedule config so it survives `set_schedule` / `disable_schedule`
rewrites.
- **Persistent TMDB collection cache with per-entry TTL** — `_movie_collection_cache` and
`_collection_cache` get written to a separate `data/tmdb_cache.json` (not encrypted — public TMDB data, no
secrets) with per-entry timestamps. Anything older than 7 days is dropped at load time and re-fetched on
next use. Big speedup for post-restart scans; easier on TMDB's rate limits. `clear_cache()` (Fresh Scan)
wipes the file too.
- **`GAPS2_CONFIG_KEY` env var** for advanced deployments that want to manage the encryption key
out-of-band (k8s secrets, systemd `EnvironmentFile`, etc.).
- **`config_store.data_dir()`** as a public helper so other services can drop sidecar files in the same
directory as `config.enc`.