### PR TITLE
Track scan history and integrate Radarr API features

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -36,12 +36,14 @@ def create_app(config_name=None):
     from app.services.emby_service import EmbyService
     from app.services.schedule_service import ScheduleService
     from app.services.notification_service import NotificationService
+    from app.services.radarr_service import RadarrService
 
     app.plex_service = PlexService()
     app.jellyfin_service = JellyfinService()
     app.emby_service = EmbyService()
     app.tmdb_service = TmdbService(app.config['TMDB_BASE_URL'], app.config['TMDB_IMAGE_BASE_URL'])
     app.notification_service = NotificationService()
+    app.radarr_service = RadarrService()
     app.schedule_service = ScheduleService()
     app.schedule_service.init_app(app)
 
@@ -57,6 +59,7 @@ def create_app(config_name=None):
     from app.blueprints.emby import emby_bp
     from app.blueprints.logs import logs_bp
     from app.blueprints.about import about_bp
+    from app.blueprints.radarr import radarr_bp
 
     app.register_blueprint(plex_bp, url_prefix='/api/plex')
     app.register_blueprint(jellyfin_bp, url_prefix='/api/jellyfin')
@@ -69,6 +72,7 @@ def create_app(config_name=None):
     app.register_blueprint(preferences_bp, url_prefix='/api/preferences')
     app.register_blueprint(logs_bp, url_prefix='/api/logs')
     app.register_blueprint(about_bp, url_prefix='/api/about')
+    app.register_blueprint(radarr_bp, url_prefix='/api/radarr')
 
     # In production, serve Angular dist
     bundle_dir = _get_bundle_dir()

--- a/backend/app/blueprints/about.py
+++ b/backend/app/blueprints/about.py
@@ -4,7 +4,7 @@ from flask import Blueprint, jsonify
 
 about_bp = Blueprint('about', __name__)
 
-VERSION = '2.4.0'
+VERSION = '2.4.1'
 
 
 def _get_commit() -> str:

--- a/backend/app/blueprints/radarr.py
+++ b/backend/app/blueprints/radarr.py
@@ -66,6 +66,15 @@ def get_root_folders():
         return jsonify(error=str(e)), 502
 
 
+@radarr_bp.route('/movies', methods=['GET'])
+def get_movies():
+    """Return TMDB ids already in the Radarr library, so the UI can flag them."""
+    try:
+        return jsonify(tmdb_ids=current_app.radarr_service.get_library_tmdb_ids())
+    except requests.exceptions.RequestException as e:
+        return jsonify(error=str(e)), 502
+
+
 @radarr_bp.route('/add', methods=['POST'])
 def add_movie():
     data = request.get_json() or {}

--- a/backend/app/blueprints/radarr.py
+++ b/backend/app/blueprints/radarr.py
@@ -1,0 +1,82 @@
+import logging
+from flask import Blueprint, jsonify, request, current_app
+import requests
+
+logger = logging.getLogger(__name__)
+
+radarr_bp = Blueprint('radarr', __name__)
+
+
+@radarr_bp.route('/config', methods=['GET'])
+def get_config():
+    cfg = current_app.radarr_service.get_config()
+    # Hide the API key on read so it isn't echoed back to the browser unnecessarily.
+    cfg['api_key'] = '••••••' if cfg.get('api_key') else ''
+    return jsonify(cfg)
+
+
+@radarr_bp.route('/config', methods=['POST'])
+def save_config():
+    data = request.get_json() or {}
+    # If the client posts back the masked placeholder, preserve the stored key.
+    api_key = data.get('api_key', '')
+    if api_key and set(api_key) == {'•'}:
+        from app.services import config_store
+        data['api_key'] = (config_store.get('radarr', {}) or {}).get('api_key', '')
+    saved = current_app.radarr_service.save_config(data)
+    saved['api_key'] = '••••••' if saved.get('api_key') else ''
+    return jsonify(saved)
+
+
+@radarr_bp.route('/config', methods=['DELETE'])
+def clear_config():
+    current_app.radarr_service.clear_config()
+    return jsonify(message='Radarr config cleared')
+
+
+@radarr_bp.route('/test', methods=['POST'])
+def test_connection():
+    data = request.get_json() or {}
+    url = data.get('url', '')
+    api_key = data.get('api_key', '')
+    # Masked placeholder means "use the stored key" so users can re-test without re-typing.
+    if api_key and set(api_key) == {'•'}:
+        from app.services import config_store
+        api_key = (config_store.get('radarr', {}) or {}).get('api_key', '')
+
+    ok, msg = current_app.radarr_service.test_connection(url, api_key)
+    if ok:
+        return jsonify(message=msg)
+    return jsonify(error=msg), 400
+
+
+@radarr_bp.route('/profiles', methods=['GET'])
+def get_profiles():
+    try:
+        return jsonify(current_app.radarr_service.get_quality_profiles())
+    except requests.exceptions.RequestException as e:
+        return jsonify(error=str(e)), 502
+
+
+@radarr_bp.route('/root-folders', methods=['GET'])
+def get_root_folders():
+    try:
+        return jsonify(current_app.radarr_service.get_root_folders())
+    except requests.exceptions.RequestException as e:
+        return jsonify(error=str(e)), 502
+
+
+@radarr_bp.route('/add', methods=['POST'])
+def add_movie():
+    data = request.get_json() or {}
+    tmdb_id = data.get('tmdb_id')
+    if not isinstance(tmdb_id, int) or tmdb_id <= 0:
+        return jsonify(error='tmdb_id is required'), 400
+
+    title = data.get('title', '')
+    year = data.get('year', 0) or 0
+
+    ok, msg = current_app.radarr_service.add_movie(tmdb_id, title=title, year=year)
+    if ok:
+        return jsonify(message=msg)
+    return jsonify(error=msg), 400

--- a/backend/app/services/radarr_service.py
+++ b/backend/app/services/radarr_service.py
@@ -1,0 +1,183 @@
+import logging
+import requests
+from app.services import config_store
+
+logger = logging.getLogger(__name__)
+
+CONFIG_KEY = 'radarr'
+DEFAULT_TIMEOUT = 10
+
+
+def _normalize_url(url: str) -> str:
+    """Strip trailing slashes and /api suffix variants."""
+    url = (url or '').strip().rstrip('/')
+    if url.endswith('/api/v3'):
+        url = url[:-len('/api/v3')]
+    elif url.endswith('/api'):
+        url = url[:-len('/api')]
+    return url
+
+
+class RadarrService:
+    """Thin wrapper around the Radarr v3 API."""
+
+    def get_config(self) -> dict:
+        saved = config_store.get(CONFIG_KEY, {}) or {}
+        return {
+            'enabled': bool(saved.get('url') and saved.get('api_key')),
+            'url': saved.get('url', ''),
+            'api_key': saved.get('api_key', ''),
+            'quality_profile_id': saved.get('quality_profile_id', 0),
+            'root_folder_path': saved.get('root_folder_path', ''),
+            'minimum_availability': saved.get('minimum_availability', 'released'),
+            'monitored': saved.get('monitored', True),
+            'search_on_add': saved.get('search_on_add', True),
+        }
+
+    def save_config(self, data: dict) -> dict:
+        cleaned = {
+            'url': _normalize_url(data.get('url', '')),
+            'api_key': (data.get('api_key') or '').strip(),
+            'quality_profile_id': int(data.get('quality_profile_id') or 0),
+            'root_folder_path': (data.get('root_folder_path') or '').strip(),
+            'minimum_availability': (data.get('minimum_availability') or 'released').strip(),
+            'monitored': bool(data.get('monitored', True)),
+            'search_on_add': bool(data.get('search_on_add', True)),
+        }
+        config_store.put(CONFIG_KEY, cleaned)
+        return self.get_config()
+
+    def clear_config(self) -> None:
+        config_store.remove(CONFIG_KEY)
+
+    @staticmethod
+    def _request(method: str, url: str, api_key: str, **kwargs) -> requests.Response:
+        headers = kwargs.pop('headers', {}) or {}
+        headers['X-Api-Key'] = api_key
+        timeout = kwargs.pop('timeout', DEFAULT_TIMEOUT)
+        return requests.request(method, url, headers=headers, timeout=timeout, **kwargs)
+
+    def test_connection(self, url: str, api_key: str) -> tuple[bool, str]:
+        url = _normalize_url(url)
+        if not url or not api_key:
+            return False, 'URL and API key are required'
+        try:
+            resp = self._request('GET', f'{url}/api/v3/system/status', api_key)
+            if resp.status_code == 200:
+                data = resp.json()
+                version = data.get('version', '?')
+                return True, f'Connected to Radarr {version}'
+            if resp.status_code == 401:
+                return False, 'Invalid API key'
+            return False, f'Radarr returned HTTP {resp.status_code}'
+        except requests.exceptions.RequestException as e:
+            return False, f'Connection failed: {e}'
+
+    def _get_url_key(self) -> tuple[str, str] | None:
+        cfg = config_store.get(CONFIG_KEY, {}) or {}
+        url = cfg.get('url')
+        api_key = cfg.get('api_key')
+        if not url or not api_key:
+            return None
+        return url, api_key
+
+    def get_quality_profiles(self) -> list[dict]:
+        creds = self._get_url_key()
+        if not creds:
+            return []
+        url, api_key = creds
+        resp = self._request('GET', f'{url}/api/v3/qualityprofile', api_key)
+        resp.raise_for_status()
+        return [{'id': p['id'], 'name': p['name']} for p in resp.json()]
+
+    def get_root_folders(self) -> list[dict]:
+        creds = self._get_url_key()
+        if not creds:
+            return []
+        url, api_key = creds
+        resp = self._request('GET', f'{url}/api/v3/rootfolder', api_key)
+        resp.raise_for_status()
+        return [
+            {
+                'path': f['path'],
+                'free_space': f.get('freeSpace', 0),
+                'accessible': f.get('accessible', True),
+            }
+            for f in resp.json()
+        ]
+
+    def add_movie(self, tmdb_id: int, title: str = '', year: int = 0) -> tuple[bool, str]:
+        """Add a movie to Radarr by TMDB id.
+
+        Returns (success, message). Treats "already added" responses as success.
+        """
+        creds = self._get_url_key()
+        if not creds:
+            return False, 'Radarr is not configured'
+        url, api_key = creds
+
+        cfg = self.get_config()
+        if not cfg['quality_profile_id'] or not cfg['root_folder_path']:
+            return False, 'Quality profile and root folder must be configured first'
+
+        # Look up movie metadata from Radarr's TMDB proxy so payload includes images/year.
+        try:
+            lookup = self._request(
+                'GET',
+                f'{url}/api/v3/movie/lookup/tmdb',
+                api_key,
+                params={'tmdbId': tmdb_id},
+            )
+            if lookup.status_code != 200:
+                return False, f'Radarr lookup failed (HTTP {lookup.status_code})'
+            movie = lookup.json()
+            if isinstance(movie, list):
+                movie = movie[0] if movie else {}
+            if not movie:
+                return False, 'Movie not found in TMDB'
+        except requests.exceptions.RequestException as e:
+            return False, f'Radarr lookup error: {e}'
+
+        payload = {
+            'tmdbId': tmdb_id,
+            'title': movie.get('title') or title,
+            'year': movie.get('year') or year,
+            'titleSlug': movie.get('titleSlug'),
+            'images': movie.get('images', []),
+            'qualityProfileId': cfg['quality_profile_id'],
+            'rootFolderPath': cfg['root_folder_path'],
+            'minimumAvailability': cfg['minimum_availability'],
+            'monitored': cfg['monitored'],
+            'addOptions': {
+                'searchForMovie': cfg['search_on_add'],
+                'monitor': 'movieOnly' if cfg['monitored'] else 'none',
+            },
+        }
+
+        try:
+            resp = self._request('POST', f'{url}/api/v3/movie', api_key, json=payload)
+        except requests.exceptions.RequestException as e:
+            return False, f'Radarr request failed: {e}'
+
+        if resp.status_code in (200, 201):
+            return True, f'Added "{payload["title"]}" to Radarr'
+
+        # Radarr returns 400 with a list of error dicts when the movie already exists.
+        if resp.status_code == 400:
+            try:
+                errors = resp.json()
+            except ValueError:
+                errors = []
+            if isinstance(errors, list):
+                messages = [e.get('errorMessage', '') for e in errors if isinstance(e, dict)]
+                joined = '; '.join(m for m in messages if m)
+                if any('already' in m.lower() for m in messages):
+                    return True, f'"{payload["title"]}" is already in Radarr'
+                if joined:
+                    return False, joined
+            return False, 'Radarr rejected the request (HTTP 400)'
+
+        if resp.status_code == 401:
+            return False, 'Invalid Radarr API key'
+
+        return False, f'Radarr returned HTTP {resp.status_code}'

--- a/backend/app/services/radarr_service.py
+++ b/backend/app/services/radarr_service.py
@@ -32,6 +32,7 @@ class RadarrService:
             'minimum_availability': saved.get('minimum_availability', 'released'),
             'monitored': saved.get('monitored', True),
             'search_on_add': saved.get('search_on_add', True),
+            'auto_route_by_decade': saved.get('auto_route_by_decade', False),
         }
 
     def save_config(self, data: dict) -> dict:
@@ -43,6 +44,7 @@ class RadarrService:
             'minimum_availability': (data.get('minimum_availability') or 'released').strip(),
             'monitored': bool(data.get('monitored', True)),
             'search_on_add': bool(data.get('search_on_add', True)),
+            'auto_route_by_decade': bool(data.get('auto_route_by_decade', False)),
         }
         config_store.put(CONFIG_KEY, cleaned)
         return self.get_config()
@@ -121,6 +123,27 @@ class RadarrService:
                 ids.append(tmdb_id)
         return ids
 
+    def _resolve_root_folder(self, year: int, url: str, api_key: str, default_path: str) -> str:
+        """Pick a root folder whose path matches the movie's decade (e.g. 2021 -> /movies/2020s).
+
+        Falls back to default_path when no folder matches or the lookup fails.
+        """
+        if not isinstance(year, int) or year <= 0:
+            return default_path
+        decade = (year // 10) * 10
+        try:
+            resp = self._request('GET', f'{url}/api/v3/rootfolder', api_key)
+            resp.raise_for_status()
+            paths = [f['path'] for f in resp.json() if f.get('path')]
+        except (requests.exceptions.RequestException, ValueError, KeyError):
+            return default_path
+        # Prefer a "2020s" style match, then a bare "2020" match.
+        for needle in (f'{decade}s', str(decade)):
+            for path in paths:
+                if needle in path:
+                    return path
+        return default_path
+
     def add_movie(self, tmdb_id: int, title: str = '', year: int = 0) -> tuple[bool, str]:
         """Add a movie to Radarr by TMDB id.
 
@@ -153,14 +176,21 @@ class RadarrService:
         except requests.exceptions.RequestException as e:
             return False, f'Radarr lookup error: {e}'
 
+        movie_year = movie.get('year') or year
+        root_folder_path = cfg['root_folder_path']
+        if cfg['auto_route_by_decade']:
+            root_folder_path = self._resolve_root_folder(
+                movie_year, url, api_key, cfg['root_folder_path']
+            )
+
         payload = {
             'tmdbId': tmdb_id,
             'title': movie.get('title') or title,
-            'year': movie.get('year') or year,
+            'year': movie_year,
             'titleSlug': movie.get('titleSlug'),
             'images': movie.get('images', []),
             'qualityProfileId': cfg['quality_profile_id'],
-            'rootFolderPath': cfg['root_folder_path'],
+            'rootFolderPath': root_folder_path,
             'minimumAvailability': cfg['minimum_availability'],
             'monitored': cfg['monitored'],
             'addOptions': {
@@ -175,7 +205,7 @@ class RadarrService:
             return False, f'Radarr request failed: {e}'
 
         if resp.status_code in (200, 201):
-            return True, f'Added "{payload["title"]}" to Radarr'
+            return True, f'Added "{payload["title"]}" to Radarr ({root_folder_path})'
 
         # Radarr returns 400 with a list of error dicts when the movie already exists.
         if resp.status_code == 400:

--- a/backend/app/services/radarr_service.py
+++ b/backend/app/services/radarr_service.py
@@ -106,6 +106,21 @@ class RadarrService:
             for f in resp.json()
         ]
 
+    def get_library_tmdb_ids(self) -> list[int]:
+        """Return the TMDB ids of every movie already in the Radarr library."""
+        creds = self._get_url_key()
+        if not creds:
+            return []
+        url, api_key = creds
+        resp = self._request('GET', f'{url}/api/v3/movie', api_key)
+        resp.raise_for_status()
+        ids = []
+        for m in resp.json():
+            tmdb_id = m.get('tmdbId')
+            if isinstance(tmdb_id, int) and tmdb_id > 0:
+                ids.append(tmdb_id)
+        return ids
+
     def add_movie(self, tmdb_id: int, title: str = '', year: int = 0) -> tuple[bool, str]:
         """Add a movie to Radarr by TMDB id.
 

--- a/backend/app/services/schedule_service.py
+++ b/backend/app/services/schedule_service.py
@@ -7,7 +7,9 @@ from app.services import config_store
 
 logger = logging.getLogger(__name__)
 
-LAST_RUN_KEY = 'schedule_last_run'
+HISTORY_KEY = 'schedule_run_history'
+LEGACY_LAST_RUN_KEY = 'schedule_last_run'  # 2.4.0 single-record format; migrated on first new write
+MAX_HISTORY = 50
 
 # Preset schedule options with cron expressions
 SCHEDULE_PRESETS = {
@@ -138,17 +140,32 @@ class ScheduleService:
         collections: int = 0,
         message: str = '',
     ) -> None:
+        entry = {
+            'timestamp': datetime.now(timezone.utc).isoformat(),
+            'status': status,
+            'library': library,
+            'missing': missing,
+            'collections': collections,
+            'message': message,
+        }
         try:
-            config_store.put(LAST_RUN_KEY, {
-                'timestamp': datetime.now(timezone.utc).isoformat(),
-                'status': status,
-                'library': library,
-                'missing': missing,
-                'collections': collections,
-                'message': message,
-            })
+            history = ScheduleService._load_history()
+            history.insert(0, entry)
+            del history[MAX_HISTORY:]
+            config_store.put(HISTORY_KEY, history)
         except OSError as e:
             logger.warning("Failed to persist scheduled scan history: %s", e)
+
+    @staticmethod
+    def _load_history() -> list[dict]:
+        """Return the run history list, migrating the legacy single-record key if needed."""
+        history = config_store.get(HISTORY_KEY)
+        if isinstance(history, list):
+            return list(history)
+        legacy = config_store.get(LEGACY_LAST_RUN_KEY)
+        if isinstance(legacy, dict):
+            return [legacy]
+        return []
 
     def _add_job(self, preset: str) -> None:
         """Add or replace the scheduled job."""
@@ -185,12 +202,14 @@ class ScheduleService:
         """Get the current schedule config."""
         saved = config_store.get('schedule', {})
         job = self._scheduler.get_job(JOB_ID)
+        history = ScheduleService._load_history()
         return {
             'enabled': saved.get('enabled', False),
             'preset': saved.get('preset', ''),
             'library': saved.get('library', ''),
             'source': saved.get('source', 'plex'),
             'next_run': str(job.next_run_time) if job else None,
-            'last_run': config_store.get(LAST_RUN_KEY),
+            'last_run': history[0] if history else None,
+            'run_history': history,
             'presets': {k: v['label'] for k, v in SCHEDULE_PRESETS.items()},
         }

--- a/frontend/src/app/app-routing.module.ts
+++ b/frontend/src/app/app-routing.module.ts
@@ -14,6 +14,7 @@ import { JellyfinSettingsComponent } from './components/settings/jellyfin-settin
 import { UserPreferencesSettingsComponent } from './components/settings/user-preferences-settings/user-preferences-settings.component';
 import { ScheduleSettingsComponent } from './components/settings/schedule-settings/schedule-settings.component';
 import { NotificationSettingsComponent } from './components/settings/notification-settings/notification-settings.component';
+import { RadarrSettingsComponent } from './components/settings/radarr-settings/radarr-settings.component';
 import { SettingsComponent } from './components/settings/settings.component';
 
 const routes: Routes = [
@@ -29,6 +30,7 @@ const routes: Routes = [
     { path: 'emby', component: EmbySettingsComponent },
     { path: 'schedule', component: ScheduleSettingsComponent },
     { path: 'notifications', component: NotificationSettingsComponent },
+    { path: 'radarr', component: RadarrSettingsComponent },
     { path: 'user-preferences', component: UserPreferencesSettingsComponent },
   ]},
   { path: '**', redirectTo: '/' }

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -22,6 +22,7 @@ import { TmdbSettingsComponent } from './components/settings/tmdb-settings/tmdb-
 import { SettingsComponent } from './components/settings/settings.component';
 import { ScheduleSettingsComponent } from './components/settings/schedule-settings/schedule-settings.component';
 import { NotificationSettingsComponent } from './components/settings/notification-settings/notification-settings.component';
+import { RadarrSettingsComponent } from './components/settings/radarr-settings/radarr-settings.component';
 import { ConfirmModalComponent } from './components/confirm-modal/confirm-modal.component';
 import { LogsComponent } from './components/logs/logs.component';
 
@@ -39,6 +40,7 @@ import { LogsComponent } from './components/logs/logs.component';
         TmdbSettingsComponent,
         ScheduleSettingsComponent,
         NotificationSettingsComponent,
+        RadarrSettingsComponent,
         SettingsComponent,
         LogsComponent
     ],

--- a/frontend/src/app/components/recommended/recommended.component.html
+++ b/frontend/src/app/components/recommended/recommended.component.html
@@ -319,6 +319,15 @@
               </a>
               <div *ngIf="!gap.tmdbId" class="rec-title">{{ gap.name }}</div>
               <div class="rec-year">{{ gap.year }}</div>
+              <button
+                *ngIf="radarrEnabled && !gap.owned && !isIgnored(gap) && gap.tmdbId"
+                class="btn btn-sm radarr-btn mt-2"
+                [ngClass]="radarrButtonClass(gap.tmdbId)"
+                [disabled]="radarrStatus.get(gap.tmdbId) === 'sending' || radarrStatus.get(gap.tmdbId) === 'sent'"
+                [title]="radarrErrors.get(gap.tmdbId) || 'Add this movie to Radarr'"
+                (click)="sendToRadarr(gap, $event)">
+                {{ radarrButtonLabel(gap.tmdbId) }}
+              </button>
             </div>
           </div>
         </div>

--- a/frontend/src/app/components/recommended/recommended.component.scss
+++ b/frontend/src/app/components/recommended/recommended.component.scss
@@ -233,6 +233,12 @@
   font-size: 12px;
 }
 
+.radarr-btn {
+  font-size: 11px;
+  padding: 2px 8px;
+  width: 100%;
+}
+
 /* Scan progress */
 .scan-progress-container {
   max-width: 600px;

--- a/frontend/src/app/components/recommended/recommended.component.ts
+++ b/frontend/src/app/components/recommended/recommended.component.ts
@@ -631,7 +631,23 @@ export class RecommendedComponent implements OnInit, OnDestroy {
   refreshRadarrStatus(): void {
     this.radarrService.getConfig().pipe(catchError(() => of(null))).subscribe(cfg => {
       this.radarrEnabled = !!(cfg && cfg.enabled);
+      if (this.radarrEnabled) {
+        this.loadRadarrLibrary();
+      }
     });
+  }
+
+  /** Flag movies already in the Radarr library so they show as "In Radarr". */
+  loadRadarrLibrary(): void {
+    this.radarrService.getLibraryTmdbIds()
+      .pipe(catchError(() => of({ tmdb_ids: [] })))
+      .subscribe(res => {
+        for (const id of res.tmdb_ids || []) {
+          if (this.radarrStatus.get(id) !== 'sending') {
+            this.radarrStatus.set(id, 'sent');
+          }
+        }
+      });
   }
 
   sendToRadarr(gap: CollectionGap, event: Event): void {

--- a/frontend/src/app/components/recommended/recommended.component.ts
+++ b/frontend/src/app/components/recommended/recommended.component.ts
@@ -13,6 +13,7 @@ import { CollectionGap } from '../../models/recommendation.model';
 import { ActiveServerResponse, MediaLibrary } from '../../models/media-server.model';
 import { PreferencesService } from '../../services/preferences.service';
 import { ExportService, ExportFormat } from '../../services/export.service';
+import { RadarrService } from '../../services/radarr.service';
 
 interface CollectionGroup {
   name: string;
@@ -82,6 +83,13 @@ export class RecommendedComponent implements OnInit, OnDestroy {
   scanProgress: ScanProgress | null = null;
   freshScanActive = false;
   showFreshScanConfirm = false;
+
+  // Radarr
+  radarrEnabled = false;
+  // tmdbId -> 'sending' | 'sent' | 'error' so the button can swap label/state without
+  // affecting other movies. 'sent' covers both "newly added" and "already exists".
+  radarrStatus = new Map<number, 'sending' | 'sent' | 'error'>();
+  radarrErrors = new Map<number, string>();
   // Cache of completed scans keyed by sorted-library combination, so toggling
   // library selection back to any previously-scanned set restores its gaps
   // without re-running. In-memory only; backend persists just the most recent.
@@ -97,10 +105,12 @@ export class RecommendedComponent implements OnInit, OnDestroy {
     private recommendationService: RecommendationService,
     private preferencesService: PreferencesService,
     private exportService: ExportService,
+    private radarrService: RadarrService,
     private router: Router,
   ) {}
 
   ngOnInit(): void {
+    this.refreshRadarrStatus();
     this.loadContext(true);
 
     // Re-load context on every return to /recommended so prefs / server changes
@@ -615,6 +625,52 @@ export class RecommendedComponent implements OnInit, OnDestroy {
           )
         }))
         .filter(group => group.gaps.length > 0);
+    }
+  }
+
+  refreshRadarrStatus(): void {
+    this.radarrService.getConfig().pipe(catchError(() => of(null))).subscribe(cfg => {
+      this.radarrEnabled = !!(cfg && cfg.enabled);
+    });
+  }
+
+  sendToRadarr(gap: CollectionGap, event: Event): void {
+    event.stopPropagation();
+    event.preventDefault();
+    if (!gap.tmdbId || !this.radarrEnabled) {
+      return;
+    }
+    if (this.radarrStatus.get(gap.tmdbId) === 'sending') {
+      return;
+    }
+    this.radarrStatus.set(gap.tmdbId, 'sending');
+    this.radarrErrors.delete(gap.tmdbId);
+    const yearNum = parseInt(gap.year, 10) || 0;
+    this.radarrService.addMovie(gap.tmdbId, gap.name, yearNum).subscribe({
+      next: () => this.radarrStatus.set(gap.tmdbId!, 'sent'),
+      error: (err) => {
+        this.radarrStatus.set(gap.tmdbId!, 'error');
+        this.radarrErrors.set(gap.tmdbId!, err.error?.error || 'Failed to add to Radarr');
+      },
+    });
+  }
+
+  radarrButtonLabel(tmdbId: number | undefined): string {
+    if (!tmdbId) return 'Send to Radarr';
+    switch (this.radarrStatus.get(tmdbId)) {
+      case 'sending': return 'Sending...';
+      case 'sent': return 'In Radarr';
+      case 'error': return 'Retry';
+      default: return 'Send to Radarr';
+    }
+  }
+
+  radarrButtonClass(tmdbId: number | undefined): string {
+    if (!tmdbId) return 'btn-outline-primary';
+    switch (this.radarrStatus.get(tmdbId)) {
+      case 'sent': return 'btn-success';
+      case 'error': return 'btn-outline-danger';
+      default: return 'btn-outline-primary';
     }
   }
 }

--- a/frontend/src/app/components/settings/radarr-settings/radarr-settings.component.html
+++ b/frontend/src/app/components/settings/radarr-settings/radarr-settings.component.html
@@ -1,0 +1,107 @@
+<div class="top-margin regular-text">
+  <p>Connect to your Radarr instance so you can send missing collection movies straight there.</p>
+
+  <!-- Status -->
+  <div class="status-indicator mb-3">
+    <span *ngIf="config.enabled" class="status-ok">&#10003; Radarr configured</span>
+    <span *ngIf="!config.enabled" class="status-missing">&#10007; Radarr not configured</span>
+  </div>
+
+  <!-- Message -->
+  <div *ngIf="message"
+       class="alert"
+       [class.alert-success]="messageType === 'success'"
+       [class.alert-danger]="messageType === 'error'">
+    {{ message }}
+  </div>
+
+  <div class="form-group mb-3">
+    <label class="form-label">Radarr URL</label>
+    <input
+      class="form-control dark-input"
+      type="text"
+      placeholder="http://localhost:7878"
+      [(ngModel)]="config.url"
+    >
+    <div class="text-muted" style="font-size: 12px;">
+      Include scheme and port. Paths like <code>/api</code> or <code>/api/v3</code> are stripped automatically.
+    </div>
+  </div>
+
+  <div class="form-group mb-3">
+    <label class="form-label">API Key</label>
+    <div class="input-group">
+      <input
+        class="form-control dark-input"
+        [type]="showKey ? 'text' : 'password'"
+        placeholder="Radarr API key (Settings &rarr; General)"
+        [(ngModel)]="config.api_key"
+      >
+      <button class="btn btn-outline-secondary" type="button" (click)="showKey = !showKey">
+        {{ showKey ? 'Hide' : 'Show' }}
+      </button>
+    </div>
+  </div>
+
+  <div class="d-flex gap-2 mb-3">
+    <button class="btn btn-info" type="button" (click)="testConnection()" [disabled]="testing || saving">
+      {{ testing ? 'Testing...' : 'Test Connection' }}
+    </button>
+    <button class="btn btn-primary" type="button" (click)="saveConfig()" [disabled]="testing || saving">
+      {{ saving ? 'Saving...' : 'Save' }}
+    </button>
+    <button
+      *ngIf="config.enabled"
+      class="btn btn-outline-danger ms-auto"
+      type="button"
+      (click)="clearConfig()"
+      [disabled]="testing || saving">
+      Clear
+    </button>
+  </div>
+
+  <hr *ngIf="config.enabled">
+
+  <div *ngIf="config.enabled">
+    <h5 class="mb-3">Defaults for added movies</h5>
+
+    <div *ngIf="loadingMeta" class="text-muted mb-3">Loading profiles and root folders...</div>
+
+    <div class="form-group mb-3">
+      <label class="form-label">Quality profile</label>
+      <select class="form-select dark-select" [(ngModel)]="config.quality_profile_id">
+        <option [ngValue]="0" disabled hidden>Select a profile...</option>
+        <option *ngFor="let p of profiles" [ngValue]="p.id">{{ p.name }}</option>
+      </select>
+    </div>
+
+    <div class="form-group mb-3">
+      <label class="form-label">Root folder</label>
+      <select class="form-select dark-select" [(ngModel)]="config.root_folder_path">
+        <option value="" disabled hidden>Select a root folder...</option>
+        <option *ngFor="let f of rootFolders" [value]="f.path">{{ f.path }}</option>
+      </select>
+    </div>
+
+    <div class="form-group mb-3">
+      <label class="form-label">Minimum availability</label>
+      <select class="form-select dark-select" [(ngModel)]="config.minimum_availability">
+        <option *ngFor="let opt of availabilityOptions" [value]="opt.value">{{ opt.label }}</option>
+      </select>
+    </div>
+
+    <div class="form-check mb-2">
+      <input class="form-check-input" type="checkbox" id="radarrMonitored" [(ngModel)]="config.monitored">
+      <label class="form-check-label text-muted" for="radarrMonitored">Monitor added movies</label>
+    </div>
+
+    <div class="form-check mb-3">
+      <input class="form-check-input" type="checkbox" id="radarrSearchOnAdd" [(ngModel)]="config.search_on_add">
+      <label class="form-check-label text-muted" for="radarrSearchOnAdd">Search on add</label>
+    </div>
+
+    <button class="btn btn-primary" type="button" (click)="saveConfig()" [disabled]="testing || saving">
+      {{ saving ? 'Saving...' : 'Save Defaults' }}
+    </button>
+  </div>
+</div>

--- a/frontend/src/app/components/settings/radarr-settings/radarr-settings.component.html
+++ b/frontend/src/app/components/settings/radarr-settings/radarr-settings.component.html
@@ -75,12 +75,24 @@
       </select>
     </div>
 
-    <div class="form-group mb-3">
+    <div class="form-group mb-2">
       <label class="form-label">Root folder</label>
       <select class="form-select dark-select" [(ngModel)]="config.root_folder_path">
         <option value="" disabled hidden>Select a root folder...</option>
         <option *ngFor="let f of rootFolders" [value]="f.path">{{ f.path }}</option>
       </select>
+    </div>
+
+    <div class="form-check mb-3">
+      <input class="form-check-input" type="checkbox" id="radarrAutoRoute" [(ngModel)]="config.auto_route_by_decade">
+      <label class="form-check-label text-muted" for="radarrAutoRoute">
+        Auto-route by decade
+      </label>
+      <div class="text-muted" style="font-size: 12px;">
+        Send each movie to the root folder whose path matches its release decade
+        (e.g. a 2021 film &rarr; <code>/movies/2020s</code>). When no folder matches,
+        the root folder selected above is used.
+      </div>
     </div>
 
     <div class="form-group mb-3">

--- a/frontend/src/app/components/settings/radarr-settings/radarr-settings.component.scss
+++ b/frontend/src/app/components/settings/radarr-settings/radarr-settings.component.scss
@@ -1,0 +1,16 @@
+.dark-input {
+  background-color: #222;
+  border: 1px solid #444;
+  color: #fff;
+
+  &::placeholder {
+    color: #666;
+  }
+
+  &:focus {
+    background-color: #333;
+    border-color: #00bc8c;
+    color: #fff;
+    box-shadow: none;
+  }
+}

--- a/frontend/src/app/components/settings/radarr-settings/radarr-settings.component.ts
+++ b/frontend/src/app/components/settings/radarr-settings/radarr-settings.component.ts
@@ -1,0 +1,141 @@
+import { Component, OnInit } from '@angular/core';
+import { RadarrService, RadarrConfig, RadarrQualityProfile, RadarrRootFolder } from '../../../services/radarr.service';
+
+@Component({
+  selector: 'app-radarr-settings',
+  templateUrl: './radarr-settings.component.html',
+  styleUrls: ['./radarr-settings.component.scss'],
+  standalone: false,
+})
+export class RadarrSettingsComponent implements OnInit {
+  config: RadarrConfig = {
+    enabled: false,
+    url: '',
+    api_key: '',
+    quality_profile_id: 0,
+    root_folder_path: '',
+    minimum_availability: 'released',
+    monitored: true,
+    search_on_add: true,
+  };
+  profiles: RadarrQualityProfile[] = [];
+  rootFolders: RadarrRootFolder[] = [];
+  testing = false;
+  saving = false;
+  loadingMeta = false;
+  showKey = false;
+  message = '';
+  messageType: 'success' | 'error' | '' = '';
+
+  availabilityOptions = [
+    { value: 'announced', label: 'Announced' },
+    { value: 'inCinemas', label: 'In Cinemas' },
+    { value: 'released', label: 'Released' },
+    { value: 'tba', label: 'TBA' },
+  ];
+
+  constructor(private radarr: RadarrService) {}
+
+  ngOnInit(): void {
+    this.radarr.getConfig().subscribe({
+      next: (cfg) => {
+        this.config = cfg;
+        if (cfg.enabled) {
+          this.loadMeta();
+        }
+      },
+      error: () => {},
+    });
+  }
+
+  loadMeta(): void {
+    this.loadingMeta = true;
+    this.radarr.getProfiles().subscribe({
+      next: (profiles) => {
+        this.profiles = profiles;
+        this.loadingMeta = false;
+      },
+      error: (err) => {
+        this.loadingMeta = false;
+        this.showMessage(err.error?.error || 'Could not load quality profiles', 'error');
+      },
+    });
+    this.radarr.getRootFolders().subscribe({
+      next: (folders) => (this.rootFolders = folders),
+      error: () => {},
+    });
+  }
+
+  testConnection(): void {
+    if (!this.config.url || !this.config.api_key) {
+      this.showMessage('URL and API key are required.', 'error');
+      return;
+    }
+    this.testing = true;
+    this.clearMessage();
+    this.radarr.testConnection(this.config.url, this.config.api_key).subscribe({
+      next: (res) => {
+        this.showMessage(res.message, 'success');
+        this.testing = false;
+      },
+      error: (err) => {
+        this.showMessage(err.error?.error || 'Connection test failed', 'error');
+        this.testing = false;
+      },
+    });
+  }
+
+  saveConfig(): void {
+    if (!this.config.url || !this.config.api_key) {
+      this.showMessage('URL and API key are required.', 'error');
+      return;
+    }
+    this.saving = true;
+    this.clearMessage();
+    this.radarr.saveConfig(this.config).subscribe({
+      next: (cfg) => {
+        this.config = cfg;
+        this.showMessage('Radarr settings saved.', 'success');
+        this.saving = false;
+        if (cfg.enabled && this.profiles.length === 0) {
+          this.loadMeta();
+        }
+      },
+      error: (err) => {
+        this.showMessage(err.error?.error || 'Failed to save settings', 'error');
+        this.saving = false;
+      },
+    });
+  }
+
+  clearConfig(): void {
+    this.radarr.clearConfig().subscribe({
+      next: () => {
+        this.config = {
+          enabled: false,
+          url: '',
+          api_key: '',
+          quality_profile_id: 0,
+          root_folder_path: '',
+          minimum_availability: 'released',
+          monitored: true,
+          search_on_add: true,
+        };
+        this.profiles = [];
+        this.rootFolders = [];
+        this.showMessage('Radarr settings cleared.', 'success');
+      },
+      error: (err) => this.showMessage(err.error?.error || 'Failed to clear settings', 'error'),
+    });
+  }
+
+  private showMessage(msg: string, type: 'success' | 'error'): void {
+    this.message = msg;
+    this.messageType = type;
+  }
+
+  private clearMessage(): void {
+    this.message = '';
+    this.messageType = '';
+  }
+}

--- a/frontend/src/app/components/settings/radarr-settings/radarr-settings.component.ts
+++ b/frontend/src/app/components/settings/radarr-settings/radarr-settings.component.ts
@@ -17,6 +17,7 @@ export class RadarrSettingsComponent implements OnInit {
     minimum_availability: 'released',
     monitored: true,
     search_on_add: true,
+    auto_route_by_decade: false,
   };
   profiles: RadarrQualityProfile[] = [];
   rootFolders: RadarrRootFolder[] = [];
@@ -120,6 +121,7 @@ export class RadarrSettingsComponent implements OnInit {
           minimum_availability: 'released',
           monitored: true,
           search_on_add: true,
+          auto_route_by_decade: false,
         };
         this.profiles = [];
         this.rootFolders = [];

--- a/frontend/src/app/components/settings/schedule-settings/schedule-settings.component.html
+++ b/frontend/src/app/components/settings/schedule-settings/schedule-settings.component.html
@@ -85,5 +85,45 @@
         </button>
       </div>
     </div>
+
+    <!-- Scan history -->
+    <div *ngIf="schedule?.run_history?.length" class="mt-4">
+      <hr>
+      <h5 class="mb-3">Scan history</h5>
+      <div class="table-responsive">
+        <table class="table table-dark table-sm" style="font-size: 13px;">
+          <thead>
+            <tr>
+              <th>When</th>
+              <th>Status</th>
+              <th>Library</th>
+              <th>Result</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr *ngFor="let run of schedule.run_history">
+              <td>{{ run.timestamp | date:'medium' }}</td>
+              <td>
+                <span class="badge"
+                      [class.bg-success]="run.status === 'success'"
+                      [class.bg-warning]="run.status === 'skipped'"
+                      [class.bg-danger]="run.status === 'error'">
+                  {{ run.status }}
+                </span>
+              </td>
+              <td>{{ run.library || '&mdash;' }}</td>
+              <td>
+                <ng-container *ngIf="run.status === 'success'">
+                  {{ run.missing }} missing across {{ run.collections }} collection(s)
+                </ng-container>
+                <ng-container *ngIf="run.status !== 'success'">
+                  {{ run.message || '&mdash;' }}
+                </ng-container>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
   </div>
 </div>

--- a/frontend/src/app/components/settings/settings.component.html
+++ b/frontend/src/app/components/settings/settings.component.html
@@ -33,6 +33,11 @@
     </li>
     <li class="nav-item">
       <a class="nav-link regular-text"
+         routerLink="/settings/radarr"
+         routerLinkActive="active">Radarr</a>
+    </li>
+    <li class="nav-item">
+      <a class="nav-link regular-text"
          routerLink="/settings/user-preferences"
          routerLinkActive="active">User Preferences</a>
     </li>

--- a/frontend/src/app/index/index.component.spec.ts
+++ b/frontend/src/app/index/index.component.spec.ts
@@ -43,7 +43,7 @@ describe('IndexComponent', () => {
     httpMock.expectOne(`${environment.apiUrl}/emby/active-server`)
       .flush(options?.emby ?? {});
     httpMock.expectOne(`${environment.apiUrl}/schedule`)
-      .flush(options?.schedule ?? { enabled: false, preset: '', next_run: null, last_run: null, presets: {} });
+      .flush(options?.schedule ?? { enabled: false, preset: '', next_run: null, last_run: null, run_history: [], presets: {} });
     httpMock.expectOne(`${environment.apiUrl}/recommendations/scan/progress`)
       .flush(options?.progress ?? { status: 'idle' });
   }
@@ -120,7 +120,7 @@ describe('IndexComponent', () => {
 
   it('should load schedule status', fakeAsync(() => {
     flushInitRequests({
-      schedule: { enabled: true, preset: 'daily', next_run: '2026-04-07T00:00:00Z', last_run: null, presets: {} },
+      schedule: { enabled: true, preset: 'daily', next_run: '2026-04-07T00:00:00Z', last_run: null, run_history: [], presets: {} },
     });
     tick();
 

--- a/frontend/src/app/services/radarr.service.ts
+++ b/frontend/src/app/services/radarr.service.ts
@@ -13,6 +13,7 @@ export interface RadarrConfig {
   minimum_availability: string;
   monitored: boolean;
   search_on_add: boolean;
+  auto_route_by_decade: boolean;
 }
 
 export interface RadarrQualityProfile {

--- a/frontend/src/app/services/radarr.service.ts
+++ b/frontend/src/app/services/radarr.service.ts
@@ -1,0 +1,64 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from '../../environments/environment';
+import { ApiMessage } from '../models/api-response.model';
+
+export interface RadarrConfig {
+  enabled: boolean;
+  url: string;
+  api_key: string;
+  quality_profile_id: number;
+  root_folder_path: string;
+  minimum_availability: string;
+  monitored: boolean;
+  search_on_add: boolean;
+}
+
+export interface RadarrQualityProfile {
+  id: number;
+  name: string;
+}
+
+export interface RadarrRootFolder {
+  path: string;
+  free_space: number;
+  accessible: boolean;
+}
+
+@Injectable({ providedIn: 'root' })
+export class RadarrService {
+  constructor(private http: HttpClient) {}
+
+  getConfig(): Observable<RadarrConfig> {
+    return this.http.get<RadarrConfig>(`${environment.apiUrl}/radarr/config`);
+  }
+
+  saveConfig(config: Partial<RadarrConfig>): Observable<RadarrConfig> {
+    return this.http.post<RadarrConfig>(`${environment.apiUrl}/radarr/config`, config);
+  }
+
+  clearConfig(): Observable<ApiMessage> {
+    return this.http.delete<ApiMessage>(`${environment.apiUrl}/radarr/config`);
+  }
+
+  testConnection(url: string, apiKey: string): Observable<ApiMessage> {
+    return this.http.post<ApiMessage>(`${environment.apiUrl}/radarr/test`, { url, api_key: apiKey });
+  }
+
+  getProfiles(): Observable<RadarrQualityProfile[]> {
+    return this.http.get<RadarrQualityProfile[]>(`${environment.apiUrl}/radarr/profiles`);
+  }
+
+  getRootFolders(): Observable<RadarrRootFolder[]> {
+    return this.http.get<RadarrRootFolder[]>(`${environment.apiUrl}/radarr/root-folders`);
+  }
+
+  addMovie(tmdbId: number, title: string, year: number): Observable<ApiMessage> {
+    return this.http.post<ApiMessage>(`${environment.apiUrl}/radarr/add`, {
+      tmdb_id: tmdbId,
+      title,
+      year,
+    });
+  }
+}

--- a/frontend/src/app/services/radarr.service.ts
+++ b/frontend/src/app/services/radarr.service.ts
@@ -54,6 +54,10 @@ export class RadarrService {
     return this.http.get<RadarrRootFolder[]>(`${environment.apiUrl}/radarr/root-folders`);
   }
 
+  getLibraryTmdbIds(): Observable<{ tmdb_ids: number[] }> {
+    return this.http.get<{ tmdb_ids: number[] }>(`${environment.apiUrl}/radarr/movies`);
+  }
+
   addMovie(tmdbId: number, title: string, year: number): Observable<ApiMessage> {
     return this.http.post<ApiMessage>(`${environment.apiUrl}/radarr/add`, {
       tmdb_id: tmdbId,

--- a/frontend/src/app/services/schedule.service.ts
+++ b/frontend/src/app/services/schedule.service.ts
@@ -19,6 +19,7 @@ export interface ScheduleConfig {
   source: string;
   next_run: string | null;
   last_run: ScheduleLastRun | null;
+  run_history: ScheduleLastRun[];
   presets: { [key: string]: string };
 }
 

--- a/frontend/src/environments/environment.prod.ts
+++ b/frontend/src/environments/environment.prod.ts
@@ -1,5 +1,5 @@
 export const environment = {
   production: true,
   apiUrl: '/api',
-  version: '2.4.0'
+  version: '2.4.1'
 };

--- a/frontend/src/environments/environment.ts
+++ b/frontend/src/environments/environment.ts
@@ -1,5 +1,5 @@
 export const environment = {
   production: false,
   apiUrl: '/api',
-  version: '2.4.0'
+  version: '2.4.1'
 };


### PR DESCRIPTION
This pull request introduces full integration with Radarr, allowing users to configure Radarr, test connections, fetch quality profiles, root folders, and add movies directly from the UI. It also improves the schedule service by tracking a full run history instead of just the last run. The frontend is updated to support Radarr configuration and to enable adding recommended movies to Radarr with clear user feedback.

**Radarr integration (backend and frontend):**

* Added `RadarrService` (`radarr_service.py`) providing methods to configure Radarr, test connections, fetch profiles/folders, get library TMDB IDs, and add movies via the Radarr API.
* Introduced `radarr` blueprint (`radarr.py`) exposing API endpoints for Radarr config, connection testing, fetching profiles/folders, library TMDB IDs, and adding movies.
* Registered `RadarrService` and `radarr` blueprint in the Flask app (`__init__.py`). [[1]](diffhunk://#diff-cdbaec5fe2aeb3e2152a80cf05ce42a5e094469ea5ef28c624858cba311e78c5R39-R46) [[2]](diffhunk://#diff-cdbaec5fe2aeb3e2152a80cf05ce42a5e094469ea5ef28c624858cba311e78c5R62) [[3]](diffhunk://#diff-cdbaec5fe2aeb3e2152a80cf05ce42a5e094469ea5ef28c624858cba311e78c5R75)
* Updated Angular frontend to include a `RadarrSettingsComponent` in routing and module declarations, enabling Radarr configuration in the UI. [[1]](diffhunk://#diff-166bf0ba59778a204139908879b1765cdefa6d588533ef7395fa41ca144aadadR17) [[2]](diffhunk://#diff-166bf0ba59778a204139908879b1765cdefa6d588533ef7395fa41ca144aadadR33) [[3]](diffhunk://#diff-a310791f1af78ce3436939d92bf03f7fff3c15bdc760f50afd68a1f5758ed2a7R25) [[4]](diffhunk://#diff-a310791f1af78ce3436939d92bf03f7fff3c15bdc760f50afd68a1f5758ed2a7R43)
* Enhanced the recommended movies UI to show an "Add to Radarr" button for each movie, with status and error feedback, using a new `RadarrService` in the frontend. [[1]](diffhunk://#diff-fc77d931f5bb3d05e97da5ea347365c7c84b909150a988cd87f780132e63e32bR322-R330) [[2]](diffhunk://#diff-1a9955d999f6b0cbc66f469db301e7efb1953556a6f69cf767d41db8ff44480fR236-R241) [[3]](diffhunk://#diff-8c075bf272c75aa7c4b4b82f0dfb2eec82aa3204bc5058bbc291f1155f3f0a04R16) [[4]](diffhunk://#diff-8c075bf272c75aa7c4b4b82f0dfb2eec82aa3204bc5058bbc291f1155f3f0a04R86-R92)

**Schedule service improvements:**

* Changed schedule service to maintain a run history (up to 50 entries), migrating from a single-record format, and updated the schedule API to return this history. [[1]](diffhunk://#diff-0733c0c829ee83541954959f7877a2a4f0079060a72c4de34832b8e188b8f3dfL10-R12) [[2]](diffhunk://#diff-0733c0c829ee83541954959f7877a2a4f0079060a72c4de34832b8e188b8f3dfL141-R169) [[3]](diffhunk://#diff-0733c0c829ee83541954959f7877a2a4f0079060a72c4de34832b8e188b8f3dfR205-R213)

**Miscellaneous:**

* Bumped backend version to `2.4.1`.