### PR TITLE
Add unified scan history feature and improve API key handling

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -66,6 +66,7 @@ def create_app(config_name=None):
     from app.blueprints.radarr import radarr_bp
     from app.blueprints.sonarr import sonarr_bp
     from app.blueprints.tvdb import tvdb_bp
+    from app.blueprints.scan_history import scan_history_bp
 
     app.register_blueprint(plex_bp, url_prefix='/api/plex')
     app.register_blueprint(jellyfin_bp, url_prefix='/api/jellyfin')
@@ -81,6 +82,7 @@ def create_app(config_name=None):
     app.register_blueprint(radarr_bp, url_prefix='/api/radarr')
     app.register_blueprint(sonarr_bp, url_prefix='/api/sonarr')
     app.register_blueprint(tvdb_bp, url_prefix='/api/tvdb')
+    app.register_blueprint(scan_history_bp, url_prefix='/api/scan-history')
 
     # In production, serve Angular dist
     bundle_dir = _get_bundle_dir()

--- a/backend/app/blueprints/about.py
+++ b/backend/app/blueprints/about.py
@@ -4,7 +4,7 @@ from flask import Blueprint, jsonify
 
 about_bp = Blueprint('about', __name__)
 
-VERSION = '2.5.0'
+VERSION = '2.5.1'
 
 
 def _get_commit() -> str:

--- a/backend/app/blueprints/radarr.py
+++ b/backend/app/blueprints/radarr.py
@@ -10,8 +10,11 @@ radarr_bp = Blueprint('radarr', __name__)
 @radarr_bp.route('/config', methods=['GET'])
 def get_config():
     cfg = current_app.radarr_service.get_config()
-    # Hide the API key on read so it isn't echoed back to the browser unnecessarily.
-    cfg['api_key'] = '••••••' if cfg.get('api_key') else ''
+    # Reveal the real API key only when the UI explicitly asks (via the Show
+    # button); otherwise echo a masked placeholder.
+    reveal = request.args.get('reveal', 'false').lower() == 'true'
+    if not reveal:
+        cfg['api_key'] = '••••••' if cfg.get('api_key') else ''
     return jsonify(cfg)
 
 

--- a/backend/app/blueprints/scan_history.py
+++ b/backend/app/blueprints/scan_history.py
@@ -1,0 +1,36 @@
+from flask import Blueprint, jsonify, request
+from app.services import scan_history
+
+scan_history_bp = Blueprint('scan_history', __name__)
+
+
+@scan_history_bp.route('', methods=['GET'])
+def get_scan_history():
+    """Return recent scan history with the latest entry per media type.
+
+    Query params:
+      - mediaType: 'movie' | 'tv' (optional filter)
+      - limit: int (optional cap on the returned list)
+
+    Gap lists are omitted to keep the payload small; fetch a single entry
+    via `/api/scan-history/<id>` to get its gaps for export.
+    """
+    media_type = request.args.get('mediaType', default=None, type=str)
+    if media_type not in ('movie', 'tv'):
+        media_type = None
+    limit = request.args.get('limit', default=None, type=int)
+    history = scan_history.load(media_type=media_type, limit=limit)
+    return jsonify(
+        history=history,
+        lastMovie=scan_history.latest('movie'),
+        lastTv=scan_history.latest('tv'),
+    )
+
+
+@scan_history_bp.route('/<entry_id>', methods=['GET'])
+def get_scan_entry(entry_id: str):
+    """Return a single history entry (including its gaps) by id."""
+    entry = scan_history.get_by_id(entry_id)
+    if not entry:
+        return jsonify(error='Scan history entry not found'), 404
+    return jsonify(entry)

--- a/backend/app/blueprints/sonarr.py
+++ b/backend/app/blueprints/sonarr.py
@@ -10,7 +10,11 @@ sonarr_bp = Blueprint('sonarr', __name__)
 @sonarr_bp.route('/config', methods=['GET'])
 def get_config():
     cfg = current_app.sonarr_service.get_config()
-    cfg['api_key'] = '••••••' if cfg.get('api_key') else ''
+    # Reveal the real API key only when the UI explicitly asks (via the Show
+    # button); otherwise echo a masked placeholder.
+    reveal = request.args.get('reveal', 'false').lower() == 'true'
+    if not reveal:
+        cfg['api_key'] = '••••••' if cfg.get('api_key') else ''
     return jsonify(cfg)
 
 

--- a/backend/app/blueprints/tvdb.py
+++ b/backend/app/blueprints/tvdb.py
@@ -25,9 +25,12 @@ def _stored_secret(field: str) -> str:
 @tvdb_bp.route('/config', methods=['GET'])
 def get_config():
     cfg = current_app.tvdb_service.get_config()
-    # Don't echo secrets back to the browser; the UI shows a masked placeholder.
-    cfg['api_key'] = _MASK if cfg.get('api_key') else ''
-    cfg['pin'] = _MASK if cfg.get('pin') else ''
+    # Reveal the real secrets only when the UI explicitly asks (via the Show
+    # button); otherwise echo masked placeholders so casual reads don't leak them.
+    reveal = request.args.get('reveal', 'false').lower() == 'true'
+    if not reveal:
+        cfg['api_key'] = _MASK if cfg.get('api_key') else ''
+        cfg['pin'] = _MASK if cfg.get('pin') else ''
     return jsonify(cfg)
 
 

--- a/backend/app/services/radarr_service.py
+++ b/backend/app/services/radarr_service.py
@@ -1,4 +1,5 @@
 import logging
+import time
 import requests
 from app.services import config_store
 
@@ -6,6 +7,13 @@ logger = logging.getLogger(__name__)
 
 CONFIG_KEY = 'radarr'
 DEFAULT_TIMEOUT = 10
+# Add can legitimately take longer than a normal read (metadata fetch, disk
+# scaffolding) so allow a bigger window before we fall back to verification.
+ADD_TIMEOUT = 30
+# After a POST timeout, Radarr may still be processing — re-check the library
+# a few times before declaring failure.
+VERIFY_ATTEMPTS = 3
+VERIFY_INTERVAL_SECONDS = 2
 
 
 def _normalize_url(url: str) -> str:
@@ -123,6 +131,21 @@ class RadarrService:
                 ids.append(tmdb_id)
         return ids
 
+    def _movie_in_library(self, tmdb_id: int) -> bool:
+        """Quick library probe used to confirm an add after a POST timeout."""
+        try:
+            return tmdb_id in self.get_library_tmdb_ids()
+        except requests.exceptions.RequestException:
+            return False
+
+    def _wait_until_added(self, tmdb_id: int) -> bool:
+        """Poll the library a few times to see whether Radarr finished the add."""
+        for _ in range(VERIFY_ATTEMPTS):
+            if self._movie_in_library(tmdb_id):
+                return True
+            time.sleep(VERIFY_INTERVAL_SECONDS)
+        return False
+
     def _resolve_root_folder(self, year: int, url: str, api_key: str, default_path: str) -> str:
         """Pick a root folder whose path matches the movie's decade (e.g. 2021 -> /movies/2020s).
 
@@ -200,7 +223,17 @@ class RadarrService:
         }
 
         try:
-            resp = self._request('POST', f'{url}/api/v3/movie', api_key, json=payload)
+            resp = self._request(
+                'POST', f'{url}/api/v3/movie', api_key, json=payload, timeout=ADD_TIMEOUT,
+            )
+        except requests.exceptions.Timeout:
+            # Radarr is slow but probably still processing — confirm via the library.
+            logger.warning(
+                "Radarr POST /movie timed out for tmdb=%s; verifying via library", tmdb_id,
+            )
+            if self._wait_until_added(tmdb_id):
+                return True, f'Added "{payload["title"]}" to Radarr (confirmed after slow response)'
+            return False, 'Radarr did not respond in time; the movie is not yet in the library'
         except requests.exceptions.RequestException as e:
             return False, f'Radarr request failed: {e}'
 

--- a/backend/app/services/scan_history.py
+++ b/backend/app/services/scan_history.py
@@ -1,0 +1,118 @@
+"""Unified scan history shared by manual and scheduled scans, movies and TV.
+
+Each completed scan appends a single entry so the dashboard can render a
+"recent scans" list across both media types and the scan-history page can
+export the gaps that were found.
+"""
+
+import logging
+import uuid
+from datetime import datetime, timezone
+
+from app.services import config_store
+
+logger = logging.getLogger(__name__)
+
+HISTORY_KEY = 'scan_history'
+MAX_HISTORY = 50
+
+
+def _strip_gap(media_type: str, gap: dict) -> dict:
+    """Keep only the fields the export needs, so the persisted blob stays small."""
+    if media_type == 'tv':
+        return {
+            'tvdbId': gap.get('tvdbId'),
+            'name': gap.get('name', ''),
+            'year': gap.get('year', ''),
+            'franchiseName': gap.get('franchiseName', ''),
+            'owned': bool(gap.get('owned', False)),
+        }
+    return {
+        'tmdbId': gap.get('tmdbId'),
+        'name': gap.get('name', ''),
+        'year': gap.get('year', ''),
+        'collectionName': gap.get('collectionName', ''),
+        'owned': bool(gap.get('owned', False)),
+    }
+
+
+def record(
+    media_type: str,
+    libraries: list[str],
+    total_owned: int,
+    missing: int,
+    status: str = 'success',
+    trigger: str = 'manual',
+    message: str = '',
+    completed_at: str | None = None,
+    gaps: list[dict] | None = None,
+) -> None:
+    """Append a scan record to the persistent history (capped at MAX_HISTORY)."""
+    mt = 'tv' if media_type == 'tv' else 'movie'
+    entry = {
+        'id': uuid.uuid4().hex,
+        'timestamp': completed_at or datetime.now(timezone.utc).isoformat(),
+        'mediaType': mt,
+        'libraries': list(libraries or []),
+        'totalOwned': int(total_owned or 0),
+        'missing': int(missing or 0),
+        'status': status,
+        'trigger': trigger,  # 'manual' | 'scheduled'
+        'message': message,
+        'gaps': [_strip_gap(mt, g) for g in (gaps or [])],
+    }
+    try:
+        history = _load_raw()
+        history.insert(0, entry)
+        del history[MAX_HISTORY:]
+        config_store.put(HISTORY_KEY, history)
+    except OSError as e:
+        logger.warning("Failed to persist scan history: %s", e)
+
+
+def _load_raw() -> list[dict]:
+    raw = config_store.get(HISTORY_KEY)
+    return list(raw) if isinstance(raw, list) else []
+
+
+def _summary(entry: dict) -> dict:
+    """Strip the gap list for list responses, exposing hasGaps as a flag."""
+    summary = {k: v for k, v in entry.items() if k != 'gaps'}
+    summary['hasGaps'] = bool(entry.get('gaps'))
+    return summary
+
+
+def load(
+    media_type: str | None = None,
+    limit: int | None = None,
+    include_gaps: bool = False,
+) -> list[dict]:
+    """Return scan history, newest first, optionally filtered by media type.
+
+    Gaps are stripped by default so the list endpoint stays small; pass
+    include_gaps=True when callers actually need them.
+    """
+    history = _load_raw()
+    if media_type in ('movie', 'tv'):
+        history = [e for e in history if e.get('mediaType') == media_type]
+    if isinstance(limit, int) and limit > 0:
+        history = history[:limit]
+    if not include_gaps:
+        history = [_summary(e) for e in history]
+    return history
+
+
+def latest(media_type: str) -> dict | None:
+    """Return the newest entry summary for the given media type."""
+    for entry in _load_raw():
+        if entry.get('mediaType') == media_type:
+            return _summary(entry)
+    return None
+
+
+def get_by_id(entry_id: str) -> dict | None:
+    """Return a single entry (with gaps) by its id, or None."""
+    for entry in _load_raw():
+        if entry.get('id') == entry_id:
+            return entry
+    return None

--- a/backend/app/services/scan_history.py
+++ b/backend/app/services/scan_history.py
@@ -6,6 +6,7 @@ export the gaps that were found.
 """
 
 import logging
+import threading
 import uuid
 from datetime import datetime, timezone
 
@@ -15,6 +16,12 @@ logger = logging.getLogger(__name__)
 
 HISTORY_KEY = 'scan_history'
 MAX_HISTORY = 50
+
+# Serializes record()'s load/insert/put so two scans completing concurrently
+# (e.g. scheduled movie + TV jobs, or a manual scan finishing alongside a
+# scheduled one) can't both load the same history and lose one entry when the
+# later put() overwrites the earlier.
+_RECORD_LOCK = threading.Lock()
 
 
 def _strip_gap(media_type: str, gap: dict) -> dict:
@@ -62,10 +69,11 @@ def record(
         'gaps': [_strip_gap(mt, g) for g in (gaps or [])],
     }
     try:
-        history = _load_raw()
-        history.insert(0, entry)
-        del history[MAX_HISTORY:]
-        config_store.put(HISTORY_KEY, history)
+        with _RECORD_LOCK:
+            history = _load_raw()
+            history.insert(0, entry)
+            del history[MAX_HISTORY:]
+            config_store.put(HISTORY_KEY, history)
     except OSError as e:
         logger.warning("Failed to persist scan history: %s", e)
 

--- a/backend/app/services/schedule_service.py
+++ b/backend/app/services/schedule_service.py
@@ -3,7 +3,7 @@ from datetime import datetime, timezone
 
 from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.triggers.cron import CronTrigger
-from app.services import config_store
+from app.services import config_store, scan_history
 
 logger = logging.getLogger(__name__)
 
@@ -140,7 +140,9 @@ class ScheduleService:
                 library_name, len(missing), collections,
             )
             self._record_last_run(
-                status='success', library=library_name, missing=len(missing), collections=collections,
+                status='success', library=library_name, missing=len(missing),
+                collections=collections, total_owned=len(owned_ids),
+                gaps=missing,
             )
             self._app.notification_service.notify_scan_results(
                 len(missing), collections, library_name, media_type='movie'
@@ -200,7 +202,8 @@ class ScheduleService:
             )
             self._record_last_run(
                 status='success', library=tv_library, missing=len(missing),
-                collections=franchises, media_type='tv',
+                collections=franchises, media_type='tv', total_owned=len(owned_ids),
+                gaps=missing,
             )
             self._app.notification_service.notify_scan_results(
                 len(missing), franchises, tv_library, media_type='tv'
@@ -219,9 +222,12 @@ class ScheduleService:
         collections: int = 0,
         message: str = '',
         media_type: str = 'movie',
+        total_owned: int = 0,
+        gaps: list[dict] | None = None,
     ) -> None:
+        timestamp = datetime.now(timezone.utc).isoformat()
         entry = {
-            'timestamp': datetime.now(timezone.utc).isoformat(),
+            'timestamp': timestamp,
             'status': status,
             'library': library,
             'missing': missing,
@@ -236,6 +242,19 @@ class ScheduleService:
             config_store.put(HISTORY_KEY, history)
         except OSError as e:
             logger.warning("Failed to persist scheduled scan history: %s", e)
+        # Mirror into the unified scan history so the dashboard sees scheduled
+        # runs alongside manual ones.
+        scan_history.record(
+            media_type=media_type,
+            libraries=[library] if library else [],
+            total_owned=total_owned,
+            missing=missing,
+            status=status,
+            trigger='scheduled',
+            message=message,
+            completed_at=timestamp,
+            gaps=gaps,
+        )
 
     @staticmethod
     def _load_history() -> list[dict]:

--- a/backend/app/services/sonarr_service.py
+++ b/backend/app/services/sonarr_service.py
@@ -1,4 +1,5 @@
 import logging
+import time
 import requests
 from app.services import config_store
 
@@ -6,6 +7,13 @@ logger = logging.getLogger(__name__)
 
 CONFIG_KEY = 'sonarr'
 DEFAULT_TIMEOUT = 10
+# Add can legitimately take longer than a normal read (metadata fetch, disk
+# scaffolding) so allow a bigger window before we fall back to verification.
+ADD_TIMEOUT = 30
+# After a POST timeout, Sonarr may still be processing — re-check the library
+# a few times before declaring failure.
+VERIFY_ATTEMPTS = 3
+VERIFY_INTERVAL_SECONDS = 2
 
 
 def _normalize_url(url: str) -> str:
@@ -126,6 +134,21 @@ class SonarrService:
                 ids.append(tvdb_id)
         return ids
 
+    def _series_in_library(self, tvdb_id: int) -> bool:
+        """Quick library probe used to confirm an add after a POST timeout."""
+        try:
+            return tvdb_id in self.get_library_tvdb_ids()
+        except requests.exceptions.RequestException:
+            return False
+
+    def _wait_until_added(self, tvdb_id: int) -> bool:
+        """Poll the library a few times to see whether Sonarr finished the add."""
+        for _ in range(VERIFY_ATTEMPTS):
+            if self._series_in_library(tvdb_id):
+                return True
+            time.sleep(VERIFY_INTERVAL_SECONDS)
+        return False
+
     def add_series(self, tvdb_id: int, title: str = '') -> tuple[bool, str]:
         """Add a series to Sonarr by TheTVDB id.
 
@@ -175,7 +198,17 @@ class SonarrService:
         }
 
         try:
-            resp = self._request('POST', f'{url}/api/v3/series', api_key, json=payload)
+            resp = self._request(
+                'POST', f'{url}/api/v3/series', api_key, json=payload, timeout=ADD_TIMEOUT,
+            )
+        except requests.exceptions.Timeout:
+            # Sonarr is slow but probably still processing — confirm via the library.
+            logger.warning(
+                "Sonarr POST /series timed out for tvdb=%s; verifying via library", tvdb_id,
+            )
+            if self._wait_until_added(tvdb_id):
+                return True, f'Added "{payload["title"]}" to Sonarr (confirmed after slow response)'
+            return False, 'Sonarr did not respond in time; the series is not yet in the library'
         except requests.exceptions.RequestException as e:
             return False, f'Sonarr request failed: {e}'
 

--- a/backend/app/services/tmdb_service.py
+++ b/backend/app/services/tmdb_service.py
@@ -5,7 +5,7 @@ import threading
 import time
 from datetime import datetime, timezone
 import requests
-from app.services import config_store
+from app.services import config_store, scan_history
 
 logger = logging.getLogger(__name__)
 
@@ -439,11 +439,31 @@ class TmdbService:
                 })
             except OSError as e:
                 logger.warning("Failed to persist last_scan: %s", e)
+            missing_gaps = [g for g in final_gaps if not g.get('owned')]
+            scan_history.record(
+                media_type='movie',
+                libraries=libraries,
+                total_owned=len(owned_tmdb_ids),
+                missing=len(missing_gaps),
+                status='success',
+                trigger='manual',
+                completed_at=completed_at,
+                gaps=missing_gaps,
+            )
         except Exception as e:
             with self._scan_progress_lock:
                 if self._scan_generation == generation:
                     self._scan_progress['error'] = str(e)
                     self._scan_progress['status'] = 'error'
+            scan_history.record(
+                media_type='movie',
+                libraries=libraries,
+                total_owned=len(owned_tmdb_ids),
+                missing=0,
+                status='error',
+                trigger='manual',
+                message=str(e),
+            )
 
     def find_collection_gaps(
         self,

--- a/backend/app/services/tvdb_service.py
+++ b/backend/app/services/tvdb_service.py
@@ -8,7 +8,7 @@ from datetime import datetime, timezone
 
 import requests
 
-from app.services import config_store
+from app.services import config_store, scan_history
 
 logger = logging.getLogger(__name__)
 
@@ -615,9 +615,29 @@ class TvdbService:
                 })
             except OSError as e:
                 logger.warning("Failed to persist last_tv_scan: %s", e)
+            missing_gaps = [g for g in gaps if not g.get('owned')]
+            scan_history.record(
+                media_type='tv',
+                libraries=libraries,
+                total_owned=len(owned_series_ids),
+                missing=len(missing_gaps),
+                status='success',
+                trigger='manual',
+                completed_at=completed_at,
+                gaps=missing_gaps,
+            )
         except Exception as e:
             logger.exception("TVDB scan failed")
             with self._scan_progress_lock:
                 if self._scan_generation == generation:
                     self._scan_progress['error'] = str(e)
                     self._scan_progress['status'] = 'error'
+            scan_history.record(
+                media_type='tv',
+                libraries=libraries,
+                total_owned=len(owned_series_ids),
+                missing=0,
+                status='error',
+                trigger='manual',
+                message=str(e),
+            )

--- a/frontend/src/app/app-routing.module.ts
+++ b/frontend/src/app/app-routing.module.ts
@@ -4,6 +4,7 @@ import { RouterModule, Routes } from '@angular/router';
 import { RecommendedComponent } from './components/recommended/recommended.component';
 import { AboutComponent } from './components/about/about.component';
 import { LogsComponent } from './components/logs/logs.component';
+import { ScanHistoryComponent } from './components/scan-history/scan-history.component';
 import { IndexComponent } from './index/index.component';
 
 //Settings
@@ -24,6 +25,7 @@ const routes: Routes = [
   { path: 'recommended', component: RecommendedComponent, data: { reuse: true } },
   { path: 'about', component: AboutComponent },
   { path: 'logs', component: LogsComponent },
+  { path: 'scan-history', component: ScanHistoryComponent },
   { path: 'settings', component: SettingsComponent, children: [
     { path: '', redirectTo: 'tmdb', pathMatch: 'full' },
     { path: 'tmdb', component: TmdbSettingsComponent },

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -26,12 +26,14 @@ import { RadarrSettingsComponent } from './components/settings/radarr-settings/r
 import { SonarrSettingsComponent } from './components/settings/sonarr-settings/sonarr-settings.component';
 import { TvdbSettingsComponent } from './components/settings/tvdb-settings/tvdb-settings.component';
 import { ConfirmModalComponent } from './components/confirm-modal/confirm-modal.component';
+import { ScanHistoryComponent } from './components/scan-history/scan-history.component';
 import { LogsComponent } from './components/logs/logs.component';
 
 @NgModule({ declarations: [
         AppComponent,
         HeaderComponent,
         ConfirmModalComponent,
+        ScanHistoryComponent,
         RecommendedComponent,
         AboutComponent,
         IndexComponent,

--- a/frontend/src/app/components/scan-history/scan-history.component.html
+++ b/frontend/src/app/components/scan-history/scan-history.component.html
@@ -1,0 +1,108 @@
+<div class="container top-margin scan-history-page">
+  <div class="page-header">
+    <div>
+      <h3 class="regular-text mb-1">Scan History</h3>
+      <p class="text-muted mb-0">
+        Recent movie and TV gap scans, manual and scheduled. Export the gap list for any scan from its row.
+      </p>
+    </div>
+    <a [routerLink]="['/']" class="back-link">&lsaquo; Back to dashboard</a>
+  </div>
+
+  <div class="toolbar">
+    <div class="filter-group" role="tablist" aria-label="Filter scan history by media type">
+      <button
+        type="button"
+        class="filter-btn"
+        [class.active]="mediaTypeFilter === 'all'"
+        (click)="setFilter('all')"
+      >All</button>
+      <button
+        type="button"
+        class="filter-btn"
+        [class.active]="mediaTypeFilter === 'movie'"
+        (click)="setFilter('movie')"
+      >Movies</button>
+      <button
+        type="button"
+        class="filter-btn"
+        [class.active]="mediaTypeFilter === 'tv'"
+        (click)="setFilter('tv')"
+      >TV</button>
+    </div>
+  </div>
+
+  <div *ngIf="loading" class="text-center py-4">
+    <div class="spinner"></div>
+    <p class="text-muted mt-2 mb-0">Loading scan history...</p>
+  </div>
+
+  <div *ngIf="error && !loading" class="error-text">{{ error }}</div>
+
+  <div *ngIf="!loading && !error && entries.length === 0" class="empty-text">
+    No previous scans recorded yet.
+  </div>
+
+  <div *ngIf="!loading && !error && entries.length > 0" class="table-wrapper">
+    <table class="history-table">
+      <thead>
+        <tr>
+          <th>When</th>
+          <th>Type</th>
+          <th>Library</th>
+          <th class="num">Owned</th>
+          <th class="num">Missing</th>
+          <th>Trigger</th>
+          <th>Status</th>
+          <th class="actions-col">Export</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr
+          *ngFor="let entry of entries"
+          [class.row-error]="entry.status === 'error'"
+          [class.row-skipped]="entry.status === 'skipped'"
+        >
+          <td>{{ entry.timestamp | date:'short' }}</td>
+          <td>
+            <span
+              class="badge"
+              [class.badge-movie]="entry.mediaType === 'movie'"
+              [class.badge-tv]="entry.mediaType === 'tv'"
+            >{{ entry.mediaType === 'tv' ? 'TV' : 'Movie' }}</span>
+          </td>
+          <td>{{ (entry.libraries || []).join(', ') || '—' }}</td>
+          <td class="num">{{ entry.totalOwned }}</td>
+          <td class="num">{{ entry.missing }}</td>
+          <td>{{ entry.trigger === 'scheduled' ? 'Scheduled' : 'Manual' }}</td>
+          <td>
+            <span class="status-pill" [ngClass]="'status-' + entry.status" [title]="entry.message">
+              {{ entry.status }}
+            </span>
+          </td>
+          <td class="actions-col">
+            <div class="export-cell">
+              <div class="export-buttons">
+                <button
+                  type="button"
+                  class="row-export-btn"
+                  [disabled]="!canExport(entry) || isExporting(entry, 'csv') || isExporting(entry, 'xlsx')"
+                  [title]="exportTooltip(entry, 'csv')"
+                  (click)="exportRow(entry, 'csv')"
+                >{{ isExporting(entry, 'csv') ? '…' : 'CSV' }}</button>
+                <button
+                  type="button"
+                  class="row-export-btn primary"
+                  [disabled]="!canExport(entry) || isExporting(entry, 'csv') || isExporting(entry, 'xlsx')"
+                  [title]="exportTooltip(entry, 'xlsx')"
+                  (click)="exportRow(entry, 'xlsx')"
+                >{{ isExporting(entry, 'xlsx') ? '…' : 'XLSX' }}</button>
+              </div>
+              <div *ngIf="entry.id && rowError[entry.id]" class="row-error-text">{{ rowError[entry.id] }}</div>
+            </div>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/frontend/src/app/components/scan-history/scan-history.component.scss
+++ b/frontend/src/app/components/scan-history/scan-history.component.scss
@@ -1,0 +1,254 @@
+.scan-history-page {
+  color: #ddd;
+}
+
+.page-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  gap: 16px;
+  margin-bottom: 18px;
+  flex-wrap: wrap;
+}
+
+.page-header .text-muted {
+  color: #888;
+  font-size: 13px;
+}
+
+.back-link {
+  color: #00bc8c;
+  text-decoration: none;
+  font-size: 13px;
+
+  &:hover {
+    color: #00a379;
+    text-decoration: underline;
+  }
+}
+
+.toolbar {
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 14px;
+  flex-wrap: wrap;
+}
+
+.filter-group {
+  display: flex;
+  border: 1px solid #444;
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.filter-btn {
+  background: #222;
+  color: #bbb;
+  border: none;
+  padding: 6px 14px;
+  font-size: 13px;
+  cursor: pointer;
+
+  & + .filter-btn {
+    border-left: 1px solid #444;
+  }
+
+  &:hover {
+    background: #2c2c2c;
+    color: #fff;
+  }
+
+  &.active {
+    background: #00bc8c;
+    color: #111;
+    font-weight: 600;
+  }
+}
+
+.actions-col {
+  text-align: right;
+  width: 1%;
+  white-space: nowrap;
+}
+
+.export-cell {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 4px;
+}
+
+.export-buttons {
+  display: inline-flex;
+  gap: 6px;
+}
+
+.row-export-btn {
+  background: #2d2d2d;
+  border: 1px solid #444;
+  color: #ddd;
+  padding: 4px 12px;
+  border-radius: 4px;
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  min-width: 52px;
+  transition: background-color 0.15s, color 0.15s;
+
+  &:hover:not(:disabled) {
+    background: #383838;
+    color: #fff;
+    border-color: #555;
+  }
+
+  &.primary {
+    background: #00bc8c;
+    border-color: #00bc8c;
+    color: #111;
+
+    &:hover:not(:disabled) {
+      background: #00a379;
+      border-color: #00a379;
+    }
+  }
+
+  &:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+}
+
+.row-error-text {
+  color: #e74c3c;
+  font-size: 11px;
+  max-width: 220px;
+  white-space: normal;
+  text-align: right;
+}
+
+.error-text {
+  color: #e74c3c;
+  font-size: 14px;
+  padding: 8px 0;
+}
+
+.empty-text {
+  color: #888;
+  font-size: 14px;
+  text-align: center;
+  padding: 30px 0;
+  background: #222;
+  border: 1px solid #333;
+  border-radius: 6px;
+}
+
+.table-wrapper {
+  overflow-x: auto;
+  border: 1px solid #333;
+  border-radius: 6px;
+}
+
+.history-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+  color: #ddd;
+  background: #1f1f1f;
+
+  th,
+  td {
+    padding: 10px 12px;
+    border-bottom: 1px solid #2e2e2e;
+    text-align: left;
+  }
+
+  th {
+    color: #aaa;
+    font-weight: 600;
+    background: #2a2a2a;
+    border-bottom: 1px solid #3a3a3a;
+    position: sticky;
+    top: 0;
+  }
+
+  td.num,
+  th.num {
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+  }
+
+  tbody tr:hover {
+    background: #262626;
+  }
+
+  tbody tr:last-child td {
+    border-bottom: none;
+  }
+
+  .row-error {
+    color: #e0a39d;
+  }
+
+  .row-skipped {
+    color: #999;
+  }
+}
+
+.badge {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 10px;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+
+.badge-movie {
+  background: rgba(0, 188, 140, 0.15);
+  color: #00bc8c;
+}
+
+.badge-tv {
+  background: rgba(91, 153, 255, 0.15);
+  color: #5b99ff;
+}
+
+.status-pill {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 10px;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: capitalize;
+
+  &.status-success {
+    background: rgba(0, 188, 140, 0.15);
+    color: #00bc8c;
+  }
+
+  &.status-error {
+    background: rgba(231, 76, 60, 0.15);
+    color: #e74c3c;
+  }
+
+  &.status-skipped {
+    background: rgba(226, 160, 63, 0.15);
+    color: #e2a03f;
+  }
+}
+
+.spinner {
+  display: inline-block;
+  width: 28px;
+  height: 28px;
+  border: 3px solid #555;
+  border-top-color: #00bc8c;
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}

--- a/frontend/src/app/components/scan-history/scan-history.component.spec.ts
+++ b/frontend/src/app/components/scan-history/scan-history.component.spec.ts
@@ -1,0 +1,162 @@
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { ActivatedRoute, convertToParamMap } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+import { ScanHistoryComponent } from './scan-history.component';
+import { ScanHistoryEntry } from '../../services/scan-history.service';
+import { environment } from '../../../environments/environment';
+
+describe('ScanHistoryComponent', () => {
+  let component: ScanHistoryComponent;
+  let fixture: ComponentFixture<ScanHistoryComponent>;
+  let httpMock: HttpTestingController;
+  let queryParamMap$: BehaviorSubject<ReturnType<typeof convertToParamMap>>;
+
+  const exportableEntry: ScanHistoryEntry = {
+    id: 'abc123',
+    timestamp: '2026-05-20T10:00:00Z',
+    mediaType: 'movie',
+    libraries: ['Movies'],
+    totalOwned: 50,
+    missing: 5,
+    status: 'success',
+    trigger: 'manual',
+    message: '',
+    hasGaps: true,
+  };
+
+  const legacyEntry: ScanHistoryEntry = {
+    // No id / hasGaps — pre-feature scan.
+    timestamp: '2026-05-19T10:00:00Z',
+    mediaType: 'movie',
+    libraries: ['Movies'],
+    totalOwned: 50,
+    missing: 5,
+    status: 'success',
+    trigger: 'manual',
+    message: '',
+  };
+
+  beforeEach(async () => {
+    queryParamMap$ = new BehaviorSubject(convertToParamMap({}));
+    await TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule, RouterTestingModule],
+      declarations: [ScanHistoryComponent],
+      providers: [
+        { provide: ActivatedRoute, useValue: { queryParamMap: queryParamMap$.asObservable() } },
+      ],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ScanHistoryComponent);
+    component = fixture.componentInstance;
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('loads history with no type filter by default', fakeAsync(() => {
+    fixture.detectChanges();
+    tick();
+
+    const req = httpMock.expectOne(`${environment.apiUrl}/scan-history?limit=50`);
+    expect(req.request.method).toBe('GET');
+    req.flush({ history: [exportableEntry], lastMovie: null, lastTv: null });
+
+    expect(component.entries.length).toBe(1);
+    expect(component.loading).toBeFalse();
+    expect(component.mediaTypeFilter).toBe('all');
+  }));
+
+  it('applies the type filter from the query param', fakeAsync(() => {
+    queryParamMap$.next(convertToParamMap({ type: 'tv' }));
+    fixture.detectChanges();
+    tick();
+
+    const req = httpMock.expectOne(`${environment.apiUrl}/scan-history?mediaType=tv&limit=50`);
+    req.flush({ history: [], lastMovie: null, lastTv: null });
+
+    expect(component.mediaTypeFilter).toBe('tv');
+  }));
+
+  it('shows an error message on failure', fakeAsync(() => {
+    fixture.detectChanges();
+    tick();
+
+    const req = httpMock.expectOne(`${environment.apiUrl}/scan-history?limit=50`);
+    req.flush({ error: 'kaboom' }, { status: 500, statusText: 'Server Error' });
+
+    expect(component.error).toBe('kaboom');
+    expect(component.loading).toBeFalse();
+  }));
+
+  it('canExport is true only for entries with id, hasGaps, and status=success', () => {
+    expect(component.canExport(exportableEntry)).toBeTrue();
+    expect(component.canExport(legacyEntry)).toBeFalse();
+    expect(component.canExport({ ...exportableEntry, status: 'error' })).toBeFalse();
+    expect(component.canExport({ ...exportableEntry, hasGaps: false })).toBeFalse();
+  });
+
+  it('export tooltip explains why legacy rows cannot export', () => {
+    const msg = component.exportTooltip(legacyEntry, 'csv');
+    expect(msg).toContain('re-run the scan');
+  });
+
+  it('fetches per-row gaps and writes a workbook on export', fakeAsync(() => {
+    fixture.detectChanges();
+    tick();
+
+    httpMock.expectOne(`${environment.apiUrl}/scan-history?limit=50`)
+      .flush({ history: [exportableEntry], lastMovie: null, lastTv: null });
+
+    const writeSpy = spyOn<any>(component, 'writeWorkbook');
+
+    component.exportRow(exportableEntry, 'xlsx');
+    tick();
+
+    httpMock.expectOne(`${environment.apiUrl}/scan-history/${exportableEntry.id}`).flush({
+      ...exportableEntry,
+      gaps: [{ tmdbId: 1, name: 'Movie A', year: '2020', collectionName: 'Coll', owned: false }],
+    });
+    tick();
+
+    expect(writeSpy).toHaveBeenCalled();
+    expect(component.exportingFor[exportableEntry.id!]).toBeNull();
+  }));
+
+  it('records a row-level error when fetching gaps fails', fakeAsync(() => {
+    fixture.detectChanges();
+    tick();
+
+    httpMock.expectOne(`${environment.apiUrl}/scan-history?limit=50`)
+      .flush({ history: [exportableEntry], lastMovie: null, lastTv: null });
+
+    component.exportRow(exportableEntry, 'csv');
+    tick();
+
+    httpMock.expectOne(`${environment.apiUrl}/scan-history/${exportableEntry.id}`)
+      .flush({ error: 'nope' }, { status: 404, statusText: 'Not Found' });
+    tick();
+
+    expect(component.rowError[exportableEntry.id!]).toBe('nope');
+    expect(component.exportingFor[exportableEntry.id!]).toBeNull();
+  }));
+
+  it('does not fetch when the entry is not exportable', fakeAsync(() => {
+    fixture.detectChanges();
+    tick();
+
+    httpMock.expectOne(`${environment.apiUrl}/scan-history?limit=50`)
+      .flush({ history: [legacyEntry], lastMovie: null, lastTv: null });
+
+    component.exportRow(legacyEntry, 'csv');
+    tick();
+
+    // No HTTP call should be made.
+    httpMock.verify();
+  }));
+});

--- a/frontend/src/app/components/scan-history/scan-history.component.ts
+++ b/frontend/src/app/components/scan-history/scan-history.component.ts
@@ -1,0 +1,138 @@
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+import { Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
+import * as XLSX from 'xlsx';
+import {
+  ScanHistoryEntry,
+  ScanHistoryEntryDetail,
+  ScanHistoryGap,
+  ScanHistoryService,
+} from '../../services/scan-history.service';
+
+type MediaTypeFilter = 'all' | 'movie' | 'tv';
+type ExportFormat = 'csv' | 'xlsx';
+
+@Component({
+  selector: 'app-scan-history',
+  templateUrl: './scan-history.component.html',
+  styleUrls: ['./scan-history.component.scss'],
+  standalone: false,
+})
+export class ScanHistoryComponent implements OnInit, OnDestroy {
+  loading = false;
+  error = '';
+  entries: ScanHistoryEntry[] = [];
+  mediaTypeFilter: MediaTypeFilter = 'all';
+
+  // Per-row export state, keyed by entry.id.
+  exportingFor: Record<string, ExportFormat | null> = {};
+  rowError: Record<string, string> = {};
+
+  private destroy$ = new Subject<void>();
+
+  constructor(
+    private scanHistoryService: ScanHistoryService,
+    private route: ActivatedRoute,
+    private router: Router,
+  ) {}
+
+  ngOnInit(): void {
+    this.route.queryParamMap
+      .pipe(takeUntil(this.destroy$))
+      .subscribe((params) => {
+        const type = params.get('type');
+        this.mediaTypeFilter =
+          type === 'movie' || type === 'tv' ? type : 'all';
+        this.load();
+      });
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+
+  load(): void {
+    this.loading = true;
+    this.error = '';
+    const filter =
+      this.mediaTypeFilter === 'all' ? undefined : this.mediaTypeFilter;
+    this.scanHistoryService.get(filter, 50).subscribe({
+      next: (resp) => {
+        this.entries = resp.history || [];
+        this.loading = false;
+      },
+      error: (err) => {
+        this.error = err?.error?.error || 'Failed to load scan history.';
+        this.loading = false;
+      },
+    });
+  }
+
+  setFilter(filter: MediaTypeFilter): void {
+    if (this.mediaTypeFilter === filter) return;
+    this.router.navigate([], {
+      relativeTo: this.route,
+      queryParams: filter === 'all' ? { type: null } : { type: filter },
+      queryParamsHandling: 'merge',
+    });
+  }
+
+  canExport(entry: ScanHistoryEntry): boolean {
+    return !!entry.id && !!entry.hasGaps && entry.status === 'success';
+  }
+
+  exportTooltip(entry: ScanHistoryEntry, format: ExportFormat): string {
+    if (!entry.id || !entry.hasGaps) {
+      return 'No gap details stored for this scan — re-run the scan to enable export.';
+    }
+    return `Export this scan's gap list as ${format.toUpperCase()}`;
+  }
+
+  exportRow(entry: ScanHistoryEntry, format: ExportFormat): void {
+    if (!entry.id || !this.canExport(entry)) return;
+    const id = entry.id;
+    this.exportingFor[id] = format;
+    delete this.rowError[id];
+
+    this.scanHistoryService.getById(id).subscribe({
+      next: (detail) => {
+        this.exportingFor[id] = null;
+        if (!detail.gaps || detail.gaps.length === 0) {
+          this.rowError[id] = 'No gap details stored for this scan.';
+          return;
+        }
+        this.writeWorkbook(detail, format);
+      },
+      error: (err) => {
+        this.exportingFor[id] = null;
+        this.rowError[id] = err?.error?.error || 'Failed to load gaps.';
+      },
+    });
+  }
+
+  isExporting(entry: ScanHistoryEntry, format: ExportFormat): boolean {
+    return !!entry.id && this.exportingFor[entry.id] === format;
+  }
+
+  private writeWorkbook(detail: ScanHistoryEntryDetail, format: ExportFormat): void {
+    const isTv = detail.mediaType === 'tv';
+    const rows = detail.gaps.map((g: ScanHistoryGap) => ({
+      Group: (isTv ? g.franchiseName : g.collectionName) || '',
+      Title: g.name,
+      Year: String(g.year ?? ''),
+      ID: isTv ? g.tvdbId : g.tmdbId,
+      Owned: g.owned ? 'Yes' : 'No',
+    }));
+
+    const ws = XLSX.utils.json_to_sheet(rows);
+    const wb = XLSX.utils.book_new();
+    XLSX.utils.book_append_sheet(wb, ws, 'Gaps');
+
+    const dateStr = (detail.timestamp || '').replace(/[:.]/g, '-').slice(0, 19);
+    const prefix = isTv ? 'tv-scan' : 'movie-scan';
+    const filename = `${prefix}-${dateStr || 'export'}.${format}`;
+    XLSX.writeFile(wb, filename, { bookType: format });
+  }
+}

--- a/frontend/src/app/components/settings/radarr-settings/radarr-settings.component.html
+++ b/frontend/src/app/components/settings/radarr-settings/radarr-settings.component.html
@@ -37,8 +37,8 @@
         placeholder="Radarr API key (Settings &rarr; General)"
         [(ngModel)]="config.api_key"
       >
-      <button class="btn btn-outline-secondary" type="button" (click)="showKey = !showKey">
-        {{ showKey ? 'Hide' : 'Show' }}
+      <button class="btn btn-outline-secondary" type="button" (click)="toggleShowKey()" [disabled]="revealingKey">
+        {{ revealingKey ? '...' : (showKey ? 'Hide' : 'Show') }}
       </button>
     </div>
   </div>

--- a/frontend/src/app/components/settings/radarr-settings/radarr-settings.component.ts
+++ b/frontend/src/app/components/settings/radarr-settings/radarr-settings.component.ts
@@ -25,8 +25,36 @@ export class RadarrSettingsComponent implements OnInit {
   saving = false;
   loadingMeta = false;
   showKey = false;
+  revealingKey = false;
   message = '';
   messageType: 'success' | 'error' | '' = '';
+
+  private static isMasked(value: string | undefined | null): boolean {
+    return !!value && /^•+$/.test(value);
+  }
+
+  toggleShowKey(): void {
+    if (this.showKey) {
+      this.showKey = false;
+      return;
+    }
+    if (!RadarrSettingsComponent.isMasked(this.config.api_key)) {
+      this.showKey = true;
+      return;
+    }
+    this.revealingKey = true;
+    this.radarr.getConfig(true).subscribe({
+      next: (cfg) => {
+        this.config.api_key = cfg.api_key;
+        this.showKey = true;
+        this.revealingKey = false;
+      },
+      error: () => {
+        this.revealingKey = false;
+        this.showKey = true;
+      },
+    });
+  }
 
   availabilityOptions = [
     { value: 'announced', label: 'Announced' },

--- a/frontend/src/app/components/settings/sonarr-settings/sonarr-settings.component.html
+++ b/frontend/src/app/components/settings/sonarr-settings/sonarr-settings.component.html
@@ -37,8 +37,8 @@
         placeholder="Sonarr API key (Settings &rarr; General)"
         [(ngModel)]="config.api_key"
       >
-      <button class="btn btn-outline-secondary" type="button" (click)="showKey = !showKey">
-        {{ showKey ? 'Hide' : 'Show' }}
+      <button class="btn btn-outline-secondary" type="button" (click)="toggleShowKey()" [disabled]="revealingKey">
+        {{ revealingKey ? '...' : (showKey ? 'Hide' : 'Show') }}
       </button>
     </div>
   </div>

--- a/frontend/src/app/components/settings/sonarr-settings/sonarr-settings.component.ts
+++ b/frontend/src/app/components/settings/sonarr-settings/sonarr-settings.component.ts
@@ -26,8 +26,36 @@ export class SonarrSettingsComponent implements OnInit {
   saving = false;
   loadingMeta = false;
   showKey = false;
+  revealingKey = false;
   message = '';
   messageType: 'success' | 'error' | '' = '';
+
+  private static isMasked(value: string | undefined | null): boolean {
+    return !!value && /^•+$/.test(value);
+  }
+
+  toggleShowKey(): void {
+    if (this.showKey) {
+      this.showKey = false;
+      return;
+    }
+    if (!SonarrSettingsComponent.isMasked(this.config.api_key)) {
+      this.showKey = true;
+      return;
+    }
+    this.revealingKey = true;
+    this.sonarr.getConfig(true).subscribe({
+      next: (cfg) => {
+        this.config.api_key = cfg.api_key;
+        this.showKey = true;
+        this.revealingKey = false;
+      },
+      error: () => {
+        this.revealingKey = false;
+        this.showKey = true;
+      },
+    });
+  }
 
   constructor(private sonarr: SonarrService) {}
 

--- a/frontend/src/app/components/settings/tvdb-settings/tvdb-settings.component.html
+++ b/frontend/src/app/components/settings/tvdb-settings/tvdb-settings.component.html
@@ -34,8 +34,8 @@
         placeholder="TheTVDB API key"
         [(ngModel)]="config.api_key"
       >
-      <button class="btn btn-outline-secondary" type="button" (click)="showKey = !showKey">
-        {{ showKey ? 'Hide' : 'Show' }}
+      <button class="btn btn-outline-secondary" type="button" (click)="toggleShowKey()" [disabled]="revealingKey">
+        {{ revealingKey ? '...' : (showKey ? 'Hide' : 'Show') }}
       </button>
     </div>
   </div>
@@ -49,8 +49,8 @@
         placeholder="Only needed for some User Subscription keys"
         [(ngModel)]="config.pin"
       >
-      <button class="btn btn-outline-secondary" type="button" (click)="showPin = !showPin">
-        {{ showPin ? 'Hide' : 'Show' }}
+      <button class="btn btn-outline-secondary" type="button" (click)="toggleShowPin()" [disabled]="revealingPin">
+        {{ revealingPin ? '...' : (showPin ? 'Hide' : 'Show') }}
       </button>
     </div>
   </div>

--- a/frontend/src/app/components/settings/tvdb-settings/tvdb-settings.component.ts
+++ b/frontend/src/app/components/settings/tvdb-settings/tvdb-settings.component.ts
@@ -18,10 +18,64 @@ export class TvdbSettingsComponent implements OnInit {
   saving = false;
   showKey = false;
   showPin = false;
+  revealingKey = false;
+  revealingPin = false;
   message = '';
   messageType: 'success' | 'error' | '' = '';
 
   constructor(private tvdb: TvdbService) {}
+
+  private static isMasked(value: string | undefined | null): boolean {
+    return !!value && /^•+$/.test(value);
+  }
+
+  toggleShowKey(): void {
+    if (this.showKey) {
+      this.showKey = false;
+      return;
+    }
+    if (!TvdbSettingsComponent.isMasked(this.config.api_key)) {
+      this.showKey = true;
+      return;
+    }
+    this.revealingKey = true;
+    this.tvdb.getConfig(true).subscribe({
+      next: (cfg) => {
+        this.config.api_key = cfg.api_key;
+        this.config.pin = cfg.pin;
+        this.showKey = true;
+        this.revealingKey = false;
+      },
+      error: () => {
+        this.revealingKey = false;
+        this.showKey = true;
+      },
+    });
+  }
+
+  toggleShowPin(): void {
+    if (this.showPin) {
+      this.showPin = false;
+      return;
+    }
+    if (!TvdbSettingsComponent.isMasked(this.config.pin)) {
+      this.showPin = true;
+      return;
+    }
+    this.revealingPin = true;
+    this.tvdb.getConfig(true).subscribe({
+      next: (cfg) => {
+        this.config.api_key = cfg.api_key;
+        this.config.pin = cfg.pin;
+        this.showPin = true;
+        this.revealingPin = false;
+      },
+      error: () => {
+        this.revealingPin = false;
+        this.showPin = true;
+      },
+    });
+  }
 
   ngOnInit(): void {
     this.tvdb.getConfig().subscribe({

--- a/frontend/src/app/index/index.component.html
+++ b/frontend/src/app/index/index.component.html
@@ -104,15 +104,31 @@
 
           <p *ngIf="lastMovieScan" class="scan-line">
             <span class="scan-badge badge-movie">Movies</span>
-            Found <strong>{{ lastMovieScan.missing }}</strong> gap(s) across
-            <strong>{{ lastMovieScan.totalOwned }}</strong> movies.
+            <ng-container *ngIf="lastMovieScan.status === 'success'">
+              Found <strong>{{ lastMovieScan.missing }}</strong> gap(s) across
+              <strong>{{ lastMovieScan.totalOwned }}</strong> movies.
+            </ng-container>
+            <ng-container *ngIf="lastMovieScan.status === 'skipped'">
+              Skipped<ng-container *ngIf="lastMovieScan.message">: {{ lastMovieScan.message }}</ng-container>.
+            </ng-container>
+            <ng-container *ngIf="lastMovieScan.status === 'error'">
+              Failed<ng-container *ngIf="lastMovieScan.message">: {{ lastMovieScan.message }}</ng-container>.
+            </ng-container>
             <span class="text-muted">— {{ lastMovieScan.timestamp | date:'short' }}</span>
           </p>
 
           <p *ngIf="lastTvScan" class="scan-line">
             <span class="scan-badge badge-tv">TV</span>
-            Found <strong>{{ lastTvScan.missing }}</strong> gap(s) across
-            <strong>{{ lastTvScan.totalOwned }}</strong> shows.
+            <ng-container *ngIf="lastTvScan.status === 'success'">
+              Found <strong>{{ lastTvScan.missing }}</strong> gap(s) across
+              <strong>{{ lastTvScan.totalOwned }}</strong> shows.
+            </ng-container>
+            <ng-container *ngIf="lastTvScan.status === 'skipped'">
+              Skipped<ng-container *ngIf="lastTvScan.message">: {{ lastTvScan.message }}</ng-container>.
+            </ng-container>
+            <ng-container *ngIf="lastTvScan.status === 'error'">
+              Failed<ng-container *ngIf="lastTvScan.message">: {{ lastTvScan.message }}</ng-container>.
+            </ng-container>
             <span class="text-muted">— {{ lastTvScan.timestamp | date:'short' }}</span>
           </p>
         </div>

--- a/frontend/src/app/index/index.component.html
+++ b/frontend/src/app/index/index.component.html
@@ -77,24 +77,49 @@
 
     <!-- Last Scan -->
     <div class="col-md-6 mb-3">
-      <div class="status-card" [class.status-ok]="lastScanStatus === 'done'" [class.status-missing]="lastScanStatus !== 'done'">
+      <div
+        class="status-card last-scan-card"
+        [class.status-ok]="hasAnyLastScan"
+        [class.status-missing]="!hasAnyLastScan"
+        [class.clickable]="hasAnyLastScan"
+        (click)="openHistory()"
+        role="button"
+        tabindex="0"
+        (keydown.enter)="openHistory()"
+      >
         <div class="status-icon">
-          <span *ngIf="lastScanStatus === 'done'">&#128269;</span>
-          <span *ngIf="lastScanStatus !== 'done'">&#8212;</span>
+          <span *ngIf="hasAnyLastScan">&#128269;</span>
+          <span *ngIf="!hasAnyLastScan">&#8212;</span>
         </div>
         <div class="status-body">
-          <h5>Last Scan</h5>
-          <p *ngIf="lastScanStatus === 'done'">
-            Found <strong>{{ lastScanGaps }}</strong> gap(s) across <strong>{{ lastScanTotal }}</strong> movies.
-          </p>
-          <p *ngIf="lastScanStatus !== 'done'">
+          <h5>
+            Last Scan
+            <span *ngIf="hasAnyLastScan" class="view-history-hint">View history &rsaquo;</span>
+          </h5>
+
+          <p *ngIf="!hasAnyLastScan">
             No scan results yet.
-            <a [routerLink]="['/recommended']" class="activeLink">Run a scan</a>
+            <a [routerLink]="['/recommended']" class="activeLink" (click)="$event.stopPropagation()">Run a scan</a>
+          </p>
+
+          <p *ngIf="lastMovieScan" class="scan-line">
+            <span class="scan-badge badge-movie">Movies</span>
+            Found <strong>{{ lastMovieScan.missing }}</strong> gap(s) across
+            <strong>{{ lastMovieScan.totalOwned }}</strong> movies.
+            <span class="text-muted">— {{ lastMovieScan.timestamp | date:'short' }}</span>
+          </p>
+
+          <p *ngIf="lastTvScan" class="scan-line">
+            <span class="scan-badge badge-tv">TV</span>
+            Found <strong>{{ lastTvScan.missing }}</strong> gap(s) across
+            <strong>{{ lastTvScan.totalOwned }}</strong> shows.
+            <span class="text-muted">— {{ lastTvScan.timestamp | date:'short' }}</span>
           </p>
         </div>
       </div>
     </div>
   </div>
+
 
   <!-- Quick Actions -->
   <h4 class="mt-4 text-primary">Quick Actions</h4>

--- a/frontend/src/app/index/index.component.scss
+++ b/frontend/src/app/index/index.component.scss
@@ -62,3 +62,76 @@
     text-decoration: none;
   }
 }
+
+.last-scan-card {
+  flex-direction: row;
+  align-items: flex-start;
+}
+
+.last-scan-card.clickable {
+  cursor: pointer;
+  transition: background-color 0.15s, transform 0.15s;
+
+  &:hover {
+    background-color: #353535;
+  }
+
+  &:focus-visible {
+    outline: 2px solid #00bc8c;
+    outline-offset: 2px;
+  }
+}
+
+.last-scan-card .status-body {
+  flex: 1;
+}
+
+.last-scan-card h5 {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+}
+
+.view-history-hint {
+  font-size: 12px;
+  font-weight: 400;
+  color: #00bc8c;
+  white-space: nowrap;
+}
+
+.scan-line {
+  margin-bottom: 4px !important;
+  font-size: 13px;
+  line-height: 1.5;
+
+  &:last-child {
+    margin-bottom: 0 !important;
+  }
+}
+
+.scan-line .text-muted {
+  color: #777 !important;
+  font-size: 12px;
+}
+
+.scan-badge {
+  display: inline-block;
+  padding: 1px 7px;
+  border-radius: 9px;
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  margin-right: 6px;
+  vertical-align: middle;
+
+  &.badge-movie {
+    background: rgba(0, 188, 140, 0.15);
+    color: #00bc8c;
+  }
+
+  &.badge-tv {
+    background: rgba(91, 153, 255, 0.15);
+    color: #5b99ff;
+  }
+}

--- a/frontend/src/app/index/index.component.spec.ts
+++ b/frontend/src/app/index/index.component.spec.ts
@@ -1,6 +1,8 @@
 import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { RouterTestingModule } from '@angular/router/testing';
+import { Router } from '@angular/router';
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { IndexComponent } from './index.component';
 import { environment } from '../../environments/environment';
 
@@ -13,6 +15,7 @@ describe('IndexComponent', () => {
     await TestBed.configureTestingModule({
       imports: [HttpClientTestingModule, RouterTestingModule],
       declarations: [IndexComponent],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
     }).compileComponents();
 
     fixture = TestBed.createComponent(IndexComponent);
@@ -30,7 +33,7 @@ describe('IndexComponent', () => {
     jellyfin?: any;
     emby?: any;
     schedule?: any;
-    progress?: any;
+    scanHistory?: any;
   }) {
     fixture.detectChanges();
 
@@ -44,8 +47,8 @@ describe('IndexComponent', () => {
       .flush(options?.emby ?? {});
     httpMock.expectOne(`${environment.apiUrl}/schedule`)
       .flush(options?.schedule ?? { enabled: false, preset: '', next_run: null, last_run: null, run_history: [], presets: {} });
-    httpMock.expectOne(`${environment.apiUrl}/recommendations/scan/progress`)
-      .flush(options?.progress ?? { status: 'idle' });
+    httpMock.expectOne(`${environment.apiUrl}/scan-history`)
+      .flush(options?.scanHistory ?? { history: [], lastMovie: null, lastTv: null });
   }
 
   it('should create', () => {
@@ -129,18 +132,54 @@ describe('IndexComponent', () => {
     expect(component.nextRun).toBe('2026-04-07T00:00:00Z');
   }));
 
-  it('should load last scan status when scan is done', fakeAsync(() => {
+  it('should load latest movie and TV scan summaries', fakeAsync(() => {
     flushInitRequests({
-      progress: {
-        status: 'done',
-        gaps: [{ tmdbId: 1 }, { tmdbId: 2 }],
-        total_owned: 500,
+      scanHistory: {
+        history: [],
+        lastMovie: {
+          timestamp: '2026-05-20T10:00:00Z', mediaType: 'movie', libraries: ['Movies'],
+          totalOwned: 500, missing: 42, status: 'success', trigger: 'manual', message: '',
+        },
+        lastTv: {
+          timestamp: '2026-05-19T10:00:00Z', mediaType: 'tv', libraries: ['Shows'],
+          totalOwned: 120, missing: 7, status: 'success', trigger: 'manual', message: '',
+        },
       },
     });
     tick();
 
-    expect(component.lastScanStatus).toBe('done');
-    expect(component.lastScanGaps).toBe(2);
-    expect(component.lastScanTotal).toBe(500);
+    expect(component.lastMovieScan?.missing).toBe(42);
+    expect(component.lastMovieScan?.totalOwned).toBe(500);
+    expect(component.lastTvScan?.missing).toBe(7);
+    expect(component.lastTvScan?.totalOwned).toBe(120);
+    expect(component.hasAnyLastScan).toBeTrue();
+  }));
+
+  it('navigates to /scan-history when card is clicked', fakeAsync(() => {
+    flushInitRequests({
+      scanHistory: {
+        history: [],
+        lastMovie: { timestamp: '2026-05-20T10:00:00Z', mediaType: 'movie', libraries: [], totalOwned: 1, missing: 1, status: 'success', trigger: 'manual', message: '' },
+        lastTv: null,
+      },
+    });
+    tick();
+
+    const router = TestBed.inject(Router);
+    const spy = spyOn(router, 'navigate');
+    component.openHistory();
+
+    expect(spy).toHaveBeenCalledWith(['/scan-history']);
+  }));
+
+  it('does not navigate when there is no scan history', fakeAsync(() => {
+    flushInitRequests();
+    tick();
+
+    const router = TestBed.inject(Router);
+    const spy = spyOn(router, 'navigate');
+    component.openHistory();
+
+    expect(spy).not.toHaveBeenCalled();
   }));
 });

--- a/frontend/src/app/index/index.component.ts
+++ b/frontend/src/app/index/index.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit } from '@angular/core';
+import { Router } from '@angular/router';
 import { forkJoin, of } from 'rxjs';
 import { catchError } from 'rxjs/operators';
 import { TmdbService } from '../services/tmdb/tmdb.service';
@@ -6,8 +7,7 @@ import { PlexService } from '../services/plex.service';
 import { JellyfinService } from '../services/jellyfin.service';
 import { EmbyService } from '../services/emby.service';
 import { ScheduleService, ScheduleConfig, ScheduleLastRun } from '../services/schedule.service';
-import { HttpClient } from '@angular/common/http';
-import { environment } from '../../environments/environment';
+import { ScanHistoryEntry, ScanHistoryService } from '../services/scan-history.service';
 
 @Component({
     selector: 'app-index',
@@ -27,9 +27,8 @@ export class IndexComponent implements OnInit {
   nextRun: string | null = null;
   scheduleLastRun: ScheduleLastRun | null = null;
 
-  lastScanStatus = '';
-  lastScanGaps = 0;
-  lastScanTotal = 0;
+  lastMovieScan: ScanHistoryEntry | null = null;
+  lastTvScan: ScanHistoryEntry | null = null;
 
   constructor(
     private tmdbService: TmdbService,
@@ -37,7 +36,8 @@ export class IndexComponent implements OnInit {
     private jellyfinService: JellyfinService,
     private embyService: EmbyService,
     private scheduleService: ScheduleService,
-    private http: HttpClient
+    private scanHistoryService: ScanHistoryService,
+    private router: Router,
   ) {}
 
   ngOnInit(): void {
@@ -77,15 +77,21 @@ export class IndexComponent implements OnInit {
       error: () => {}
     });
 
-    this.http.get<any>(`${environment.apiUrl}/recommendations/scan/progress`).subscribe({
-      next: (progress) => {
-        if (progress.status === 'done') {
-          this.lastScanStatus = 'done';
-          this.lastScanGaps = (progress.gaps || []).length;
-          this.lastScanTotal = progress.total_owned || 0;
-        }
+    this.scanHistoryService.get().subscribe({
+      next: (resp) => {
+        this.lastMovieScan = resp.lastMovie;
+        this.lastTvScan = resp.lastTv;
       },
-      error: () => {}
+      error: () => {},
     });
+  }
+
+  get hasAnyLastScan(): boolean {
+    return !!(this.lastMovieScan || this.lastTvScan);
+  }
+
+  openHistory(): void {
+    if (!this.hasAnyLastScan) return;
+    this.router.navigate(['/scan-history']);
   }
 }

--- a/frontend/src/app/services/radarr.service.ts
+++ b/frontend/src/app/services/radarr.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { environment } from '../../environments/environment';
 import { ApiMessage } from '../models/api-response.model';
@@ -31,8 +31,9 @@ export interface RadarrRootFolder {
 export class RadarrService {
   constructor(private http: HttpClient) {}
 
-  getConfig(): Observable<RadarrConfig> {
-    return this.http.get<RadarrConfig>(`${environment.apiUrl}/radarr/config`);
+  getConfig(reveal: boolean = false): Observable<RadarrConfig> {
+    const params = reveal ? new HttpParams().set('reveal', 'true') : undefined;
+    return this.http.get<RadarrConfig>(`${environment.apiUrl}/radarr/config`, { params });
   }
 
   saveConfig(config: Partial<RadarrConfig>): Observable<RadarrConfig> {

--- a/frontend/src/app/services/scan-history.service.ts
+++ b/frontend/src/app/services/scan-history.service.ts
@@ -1,0 +1,56 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from '../../environments/environment';
+
+export interface ScanHistoryGap {
+  // movie entries carry tmdbId + collectionName; tv entries carry tvdbId + franchiseName.
+  tmdbId?: number;
+  tvdbId?: number;
+  name: string;
+  year: string | number;
+  collectionName?: string;
+  franchiseName?: string;
+  owned: boolean;
+}
+
+export interface ScanHistoryEntry {
+  id?: string;
+  timestamp: string;
+  mediaType: 'movie' | 'tv';
+  libraries: string[];
+  totalOwned: number;
+  missing: number;
+  status: 'success' | 'skipped' | 'error';
+  trigger: 'manual' | 'scheduled';
+  message: string;
+  hasGaps?: boolean;
+}
+
+export interface ScanHistoryEntryDetail extends ScanHistoryEntry {
+  gaps: ScanHistoryGap[];
+}
+
+export interface ScanHistoryResponse {
+  history: ScanHistoryEntry[];
+  lastMovie: ScanHistoryEntry | null;
+  lastTv: ScanHistoryEntry | null;
+}
+
+@Injectable({ providedIn: 'root' })
+export class ScanHistoryService {
+  private readonly base = `${environment.apiUrl}/scan-history`;
+
+  constructor(private http: HttpClient) {}
+
+  get(mediaType?: 'movie' | 'tv', limit?: number): Observable<ScanHistoryResponse> {
+    const params: Record<string, string> = {};
+    if (mediaType) params['mediaType'] = mediaType;
+    if (limit) params['limit'] = String(limit);
+    return this.http.get<ScanHistoryResponse>(this.base, { params });
+  }
+
+  getById(id: string): Observable<ScanHistoryEntryDetail> {
+    return this.http.get<ScanHistoryEntryDetail>(`${this.base}/${encodeURIComponent(id)}`);
+  }
+}

--- a/frontend/src/app/services/sonarr.service.ts
+++ b/frontend/src/app/services/sonarr.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { environment } from '../../environments/environment';
 import { ApiMessage } from '../models/api-response.model';
@@ -30,8 +30,9 @@ export interface SonarrRootFolder {
 export class SonarrService {
   constructor(private http: HttpClient) {}
 
-  getConfig(): Observable<SonarrConfig> {
-    return this.http.get<SonarrConfig>(`${environment.apiUrl}/sonarr/config`);
+  getConfig(reveal: boolean = false): Observable<SonarrConfig> {
+    const params = reveal ? new HttpParams().set('reveal', 'true') : undefined;
+    return this.http.get<SonarrConfig>(`${environment.apiUrl}/sonarr/config`, { params });
   }
 
   saveConfig(config: Partial<SonarrConfig>): Observable<SonarrConfig> {

--- a/frontend/src/app/services/tvdb.service.ts
+++ b/frontend/src/app/services/tvdb.service.ts
@@ -50,8 +50,9 @@ export interface TvdbScanRequest {
 export class TvdbService {
   constructor(private http: HttpClient) {}
 
-  getConfig(): Observable<TvdbConfig> {
-    return this.http.get<TvdbConfig>(`${environment.apiUrl}/tvdb/config`);
+  getConfig(reveal: boolean = false): Observable<TvdbConfig> {
+    const params = reveal ? new HttpParams().set('reveal', 'true') : undefined;
+    return this.http.get<TvdbConfig>(`${environment.apiUrl}/tvdb/config`, { params });
   }
 
   saveConfig(config: Partial<TvdbConfig>): Observable<TvdbConfig> {

--- a/frontend/src/environments/environment.prod.ts
+++ b/frontend/src/environments/environment.prod.ts
@@ -1,5 +1,5 @@
 export const environment = {
   production: true,
   apiUrl: '/api',
-  version: '2.5.0'
+  version: '2.5.1'
 };

--- a/frontend/src/environments/environment.ts
+++ b/frontend/src/environments/environment.ts
@@ -1,5 +1,5 @@
 export const environment = {
   production: false,
   apiUrl: '/api',
-  version: '2.5.0'
+  version: '2.5.1'
 };


### PR DESCRIPTION
This pull request introduces a unified scan history feature for both manual and scheduled scans across movies and TV, making scan results more accessible for the dashboard and export. It also improves the reliability of Radarr and Sonarr library additions by handling timeouts more gracefully, and updates API key handling for configuration endpoints to better protect secrets. Additionally, a new API endpoint is added to access scan history, and the backend version is incremented.

**Unified Scan History and API**

* Added a new `scan_history` service (`backend/app/services/scan_history.py`) to record, summarize, and retrieve scan results for both movies and TV, supporting both manual and scheduled scans. This enables the dashboard and scan-history page to display recent scans and export missing items.
* Integrated scan history recording into scheduled (`schedule_service.py`) and manual (`tmdb_service.py`, `tvdb_service.py`) scan flows, ensuring all scans are logged in a unified format. [[1]](diffhunk://#diff-0733c0c829ee83541954959f7877a2a4f0079060a72c4de34832b8e188b8f3dfL143-R145) [[2]](diffhunk://#diff-0733c0c829ee83541954959f7877a2a4f0079060a72c4de34832b8e188b8f3dfL203-R206) [[3]](diffhunk://#diff-0733c0c829ee83541954959f7877a2a4f0079060a72c4de34832b8e188b8f3dfR245-R257) [[4]](diffhunk://#diff-ec7f8714dd1ab6c9235c94b620bd9b2bd9e7d509ca7bf3f10bd31a2170c48d0bR442-R466) [[5]](diffhunk://#diff-be419118ce8b49d024a4717a538b1303ee28803648a54c93ad06f55f9f60f02fR618-R643)
* Introduced a new API blueprint and endpoints for retrieving scan history and individual scan entries (`backend/app/blueprints/scan_history.py`), and registered the blueprint in the app initialization. [[1]](diffhunk://#diff-1cfb4ae95040550444d56a878ed6aebfb3f5499a78cb3a1f3e7b2fcd7baf98b5R1-R36) [[2]](diffhunk://#diff-cdbaec5fe2aeb3e2152a80cf05ce42a5e094469ea5ef28c624858cba311e78c5R69) [[3]](diffhunk://#diff-cdbaec5fe2aeb3e2152a80cf05ce42a5e094469ea5ef28c624858cba311e78c5R85)

**Improved API Key and Secret Handling**

* Updated the config endpoints for Radarr, Sonarr, and TVDB to only reveal API keys/secrets when explicitly requested via a `reveal` query parameter, masking them by default to avoid accidental exposure. [[1]](diffhunk://#diff-0c6644f498bd309706a3e7527ac1145d92b867958915d0c76e9f675a23421026L13-R16) [[2]](diffhunk://#diff-56003fb35def08007a4a241dcff13f0ce6a2e57673c1a06938788ff617e9cc47R13-R16) [[3]](diffhunk://#diff-d2525b4c41b9df30e9edc9f80b0748e9a145cd4c9c1a02ef30542b7f13249c87L28-R31)

**Reliability Improvements for Radarr/Sonarr Add Operations**

* Enhanced Radarr and Sonarr add operations to handle timeouts by polling the library to verify if the addition succeeded, reducing false negatives when the external service is slow. [[1]](diffhunk://#diff-8f05db3c4feafcb96043fecbfb36c601afcab692f0d57de50e3169aa8b35c545R2-R16) [[2]](diffhunk://#diff-8f05db3c4feafcb96043fecbfb36c601afcab692f0d57de50e3169aa8b35c545R134-R148) [[3]](diffhunk://#diff-8f05db3c4feafcb96043fecbfb36c601afcab692f0d57de50e3169aa8b35c545L203-R236) [[4]](diffhunk://#diff-a848498867c1dbb62312fdaab715a083da6a9df945ec96a8425ea860d791cd7fR2-R16) [[5]](diffhunk://#diff-a848498867c1dbb62312fdaab715a083da6a9df945ec96a8425ea860d791cd7fR137-R151) [[6]](diffhunk://#diff-a848498867c1dbb62312fdaab715a083da6a9df945ec96a8425ea860d791cd7fL178-R211)

**Other Updates**

* Bumped backend version from `2.5.0` to `2.5.1` in the about blueprint.

These changes collectively improve reliability, security, and observability for scan operations and configuration management.