### PR TITLE
Align future-release detection and fix gap hydration for movies

### DIFF
--- a/backend/app/blueprints/about.py
+++ b/backend/app/blueprints/about.py
@@ -4,7 +4,7 @@ from flask import Blueprint, jsonify
 
 about_bp = Blueprint('about', __name__)
 
-VERSION = '2.9.0'
+VERSION = '2.9.1'
 
 
 def _get_commit() -> str:

--- a/backend/app/services/scan_history.py
+++ b/backend/app/services/scan_history.py
@@ -24,20 +24,19 @@ MAX_HISTORY = 50
 _RECORD_LOCK = threading.Lock()
 
 
-def _is_future_release(gap: dict, is_movie: bool, today: str, current_year: int) -> bool:
+def _is_future_release(gap: dict, today: str, current_year: int) -> bool:
     """Whether a gap is an unreleased/future title.
 
     Mirror of `isFutureRelease` in
     frontend/src/app/components/recommended/recommended.component.ts — kept in
     sync so scheduled scans count gaps the same way the dashboard displays them.
-    Prefer an exact date (movie release / TV first-aired); a movie with no date
-    is treated as unannounced/future, while TV falls back to the year.
+    Prefer an exact date (movie release / TV first-aired); with no date, fall
+    back to the year, the same for movies and TV (an unparseable year counts as
+    released).
     """
     release_date = gap.get('releaseDate') or ''
     if release_date:
         return release_date[:10] > today
-    if is_movie:
-        return True
     try:
         year = int(str(gap.get('year'))[:4])
     except (TypeError, ValueError):
@@ -65,7 +64,7 @@ def actionable_missing(media_type: str, gaps: list[dict]) -> list[dict]:
     if prefs.get('hideFutureReleasesByDefault'):
         now = datetime.now(timezone.utc)
         today = now.strftime('%Y-%m-%d')
-        result = [g for g in result if not _is_future_release(g, is_movie, today, now.year)]
+        result = [g for g in result if not _is_future_release(g, today, now.year)]
     return result
 
 

--- a/backend/app/services/tmdb_service.py
+++ b/backend/app/services/tmdb_service.py
@@ -633,22 +633,21 @@ class TmdbService:
             })
         return entries
 
-    def _cached_movie_part(self, tmdb_id: int | None) -> dict | None:
-        """The cached TMDB `part` dict for a movie (poster/ratings/genres), found
-        via the warm collection membership + collection caches, or None on a miss.
-        Caller holds `_cache_lock`."""
-        if tmdb_id is None:
-            return None
-        coll_id = self._movie_collection_cache.get(tmdb_id)
-        if coll_id is None:
-            return None
-        coll = self._collection_cache.get(coll_id)
-        if not coll:
-            return None
-        for part in coll.get("parts", []):
-            if part.get("id") == tmdb_id:
-                return part
-        return None
+    def _cached_parts_by_id(self) -> dict[int, dict]:
+        """A {movie_id: part} index over every cached collection's `parts`.
+
+        A gap is a *missing* movie (a collection member the user doesn't own), so
+        its id is never a key in `_movie_collection_cache` (that maps *owned*
+        movies to their collection) — but it does appear in its collection's
+        `parts` list, poster and all. So hydration indexes the parts, not the
+        owned-membership map. Caller holds `_cache_lock`."""
+        parts: dict[int, dict] = {}
+        for coll in self._collection_cache.values():
+            for part in coll.get("parts", []):
+                pid = part.get("id")
+                if pid is not None:
+                    parts.setdefault(pid, part)
+        return parts
 
     def hydrate_gaps(self, gaps: list[dict]) -> list[dict]:
         """Re-attach display fields (poster, ratings, genres, release date) to a
@@ -661,9 +660,10 @@ class TmdbService:
         """
         out = []
         with self._cache_lock:
+            parts_by_id = self._cached_parts_by_id()
             for g in gaps:
                 tmdb_id = g.get("tmdbId")
-                part = self._cached_movie_part(tmdb_id)
+                part = parts_by_id.get(tmdb_id) if tmdb_id is not None else None
                 if not part:
                     out.append(g)
                     continue

--- a/backend/app/services/tmdb_service.py
+++ b/backend/app/services/tmdb_service.py
@@ -655,7 +655,9 @@ class TmdbService:
         list of stored/stripped movie gaps by reading the warm collection cache —
         the same data a live scan builds, with no network calls. Used to reopen a
         saved scan (scan history) in the Missing view. A gap whose movie isn't in
-        the cache is returned unchanged (just its stored fields, poster None).
+        the cache (miss or expired TTL) is returned unchanged (its stored fields,
+        poster None); the frontend's future-release filter falls back to the
+        stored year, so the title still shows without a poster.
         """
         out = []
         with self._cache_lock:

--- a/frontend/src/app/components/recommended/recommended.component.ts
+++ b/frontend/src/app/components/recommended/recommended.component.ts
@@ -1046,8 +1046,9 @@ export class RecommendedComponent implements OnInit, OnDestroy {
     const today = new Date().toISOString().slice(0, 10);
     // Prefer an exact date (movie release date or TV first-aired date).
     if (gap.releaseDate) return gap.releaseDate > today;
-    if (this.mediaType === 'movie') return true; // no date → unannounced/future
-    // TV with no first-aired date: fall back to the year.
+    // No exact date (e.g. a reopened saved scan whose gaps were stripped of the
+    // release date): fall back to the year, the same for movies and TV. An
+    // unparseable year counts as released so the title isn't hidden by default.
     const year = parseInt(String(gap.year), 10);
     return year ? year > new Date().getFullYear() : false;
   }

--- a/frontend/src/environments/environment.prod.ts
+++ b/frontend/src/environments/environment.prod.ts
@@ -1,5 +1,5 @@
 export const environment = {
   production: true,
   apiUrl: '/api',
-  version: '2.9.0'
+  version: '2.9.1'
 };

--- a/frontend/src/environments/environment.ts
+++ b/frontend/src/environments/environment.ts
@@ -1,5 +1,5 @@
 export const environment = {
   production: false,
   apiUrl: '/api',
-  version: '2.9.0'
+  version: '2.9.1'
 };


### PR DESCRIPTION
This pull request updates the application to version 2.9.1 and makes several improvements to the handling of "future release" logic for missing media titles. The changes ensure consistent behavior between the backend and frontend when determining if a movie or TV show is unreleased, and improve the way missing movie data is hydrated from the cache.

**Version bump:**

* Updated the application version to `2.9.1` in `about.py` and both environment files for frontend and backend. [[1]](diffhunk://#diff-1a11fca4bc09162a59edd13a4d8c63d97a44754ae614cc31752410ee82886bfdL7-R7) [[2]](diffhunk://#diff-5a3dab56d25aaa1d0834119d97ec5b71bb37c9468a4e7ce88e1322118e0845adL4-R4) [[3]](diffhunk://#diff-c2bff05a291576cdf2db901cd3f3c386e0b6c2b62aa3377a53897ffce44f79f5L4-R4)

**Future release logic consistency:**

* Refactored the `_is_future_release` function in `scan_history.py` to treat missing release dates the same for movies and TV shows, falling back to the year for both, and updated its usage accordingly. This matches the frontend logic and prevents movies with missing dates from always being considered unreleased. [[1]](diffhunk://#diff-4adc789e9875b61e0dda836735fe2232b782b7677e4f8f14754b33fbc91a9364L27-L40) [[2]](diffhunk://#diff-4adc789e9875b61e0dda836735fe2232b782b7677e4f8f14754b33fbc91a9364L68-R67)
* Updated the frontend's `RecommendedComponent` to match the backend logic for future release detection, using the year as a fallback for both movies and TV, and treating unparseable years as released.

**Cache hydration improvements:**

* Replaced the `_cached_movie_part` method with a new `_cached_parts_by_id` method in `tmdb_service.py` to more efficiently index cached collection parts by movie ID, ensuring missing movies can be hydrated with display data if available in any cached collection.