### PR TITLE
Enhance app features with ignore modals and similar movie discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ GAPS 2 connects to your Plex, Jellyfin, or Emby server, looks at what you own, a
 **Find what's missing**
 - **Multi-server support** — Plex (OAuth), Jellyfin, and Emby
 - **Find missing movies** from TMDB collections, and **missing TV shows** from TheTVDB's official franchise lists
+- **Discover similar movies** from a title you own, with owned/missing status powered by TMDB IDs
 - **Unified "Missing" view** with a Movies / TV Shows toggle — browse a library, scan it for gaps, or click a single title to check just its collection/franchise
 - **Find gaps by actor/actress** — search a performer (e.g. *Will Smith*) on the **Actors** page and see their full filmography split into what you own and what you're missing
 

--- a/backend/app/blueprints/about.py
+++ b/backend/app/blueprints/about.py
@@ -4,7 +4,7 @@ from flask import Blueprint, jsonify
 
 about_bp = Blueprint('about', __name__)
 
-VERSION = '2.9.1'
+VERSION = '2.10.0'
 
 
 def _get_commit() -> str:

--- a/backend/app/blueprints/recommendations.py
+++ b/backend/app/blueprints/recommendations.py
@@ -58,6 +58,45 @@ def get_gaps_for_movie():
     return jsonify(gaps=gaps)
 
 
+@recommendations_bp.route('/similar', methods=['GET'])
+def get_similar_movies():
+    """Find TMDB movies similar to one owned movie and mark library ownership."""
+    movie_id = request.args.get('movieId', type=int)
+    library_names = request.args.getlist('libraryNames')
+    source = request.args.get('source', default='plex', type=str)
+
+    if not movie_id:
+        return jsonify(error='movieId (TMDB ID) parameter is required'), 400
+    if not library_names:
+        return jsonify(error='At least one libraryNames parameter is required'), 400
+
+    api_key = current_app.tmdb_service.api_key
+    if not api_key:
+        return jsonify(error='No TMDB API key configured'), 400
+
+    cache = _get_movies_cache(source)
+    owned_ids: set[int] = set()
+    owned_title_year: set[str] = set()
+    for name in library_names:
+        library_data = cache.get(name, {})
+        owned_ids.update(library_data.get('tmdbIds', []))
+        for movie in library_data.get('movies', []):
+            title = (movie.get('name') or '').strip().lower()
+            year = str(movie.get('year') or '')
+            if title:
+                owned_title_year.add(f"{title}|{year}")
+
+    movies, error = current_app.tmdb_service.find_similar_movies(
+        api_key=api_key,
+        tmdb_id=movie_id,
+        owned_tmdb_ids=owned_ids,
+        owned_title_year=owned_title_year,
+    )
+    if error:
+        return jsonify(error=error), 502
+    return jsonify(gaps=movies)
+
+
 @recommendations_bp.route('/scan', methods=['POST'])
 def scan_library_gaps():
     """Start a library scan in the background."""

--- a/backend/app/services/tmdb_service.py
+++ b/backend/app/services/tmdb_service.py
@@ -1039,6 +1039,75 @@ class TmdbService:
         results.sort(key=lambda r: r["year"])
         return results, None
 
+    def find_similar_movies(
+        self,
+        api_key: str,
+        tmdb_id: int,
+        owned_tmdb_ids: set[int],
+        owned_title_year: set[str] | None = None,
+        pages: int = 3,
+    ) -> tuple[list[dict] | None, str | None]:
+        """Return relevance-ranked TMDB recommendations with ownership metadata."""
+        entries: list[dict] = []
+        seen_ids = {tmdb_id}
+        page_count = max(1, min(pages, 5))
+
+        for page in range(1, page_count + 1):
+            try:
+                resp = self._session.get(
+                    f"{self._base_url}/movie/{tmdb_id}/similar",
+                    params={
+                        "api_key": api_key,
+                        "language": self._language,
+                        "page": page,
+                    },
+                    timeout=10,
+                )
+                if resp.status_code != 200:
+                    if page == 1:
+                        return None, f"TMDB similar-movies request failed ({resp.status_code})"
+                    break
+                payload = resp.json()
+            except (requests.exceptions.RequestException, ValueError) as e:
+                logger.warning("TMDB similar lookup failed for %s: %s", tmdb_id, e)
+                if page == 1:
+                    return None, "Failed to fetch similar movies from TMDB"
+                break
+
+            for movie in payload.get("results", []):
+                movie_id = movie.get("id")
+                if not movie_id or movie_id in seen_ids:
+                    continue
+                seen_ids.add(movie_id)
+
+                release_date = movie.get("release_date") or ""
+                title = movie.get("title") or "Unknown"
+                title_year = f"{title.strip().lower()}|{release_date[:4]}"
+                is_owned = movie_id in owned_tmdb_ids
+                if not is_owned and owned_title_year:
+                    is_owned = title_year in owned_title_year
+
+                poster = movie.get("poster_path")
+                entries.append({
+                    "tmdbId": movie_id,
+                    "name": title,
+                    "year": release_date[:4] if release_date else "N/A",
+                    "releaseDate": release_date,
+                    "posterUrl": f"{self._image_base_url}{poster}" if poster else None,
+                    "overview": movie.get("overview", ""),
+                    "collectionName": "Similar Movies",
+                    "owned": is_owned,
+                    "voteAverage": movie.get("vote_average") or 0,
+                    "voteCount": movie.get("vote_count") or 0,
+                    "genreIds": movie.get("genre_ids") or [],
+                    "popularity": movie.get("popularity") or 0,
+                })
+
+            if page >= int(payload.get("total_pages") or 1):
+                break
+
+        return entries, None
+
     # -- Actor / actress gaps (issue #49) --
     # Unlike collection gaps (a background scan of the whole library), an actor
     # lookup is search-driven and synchronous: search a person, fetch their

--- a/frontend/src/app/app-routing.module.ts
+++ b/frontend/src/app/app-routing.module.ts
@@ -3,6 +3,7 @@ import { RouterModule, Routes } from '@angular/router';
 
 import { RecommendedComponent } from './components/recommended/recommended.component';
 import { ActorsComponent } from './components/actors/actors.component';
+import { SimilarComponent } from './components/similar/similar.component';
 import { AboutComponent } from './components/about/about.component';
 import { LogsComponent } from './components/logs/logs.component';
 import { ScanHistoryComponent } from './components/scan-history/scan-history.component';
@@ -25,6 +26,7 @@ import { SettingsComponent } from './components/settings/settings.component';
 const routes: Routes = [
   { path: '', component: IndexComponent },
   { path: 'recommended', component: RecommendedComponent, data: { reuse: true } },
+  { path: 'similar', component: SimilarComponent },
   { path: 'actors', component: ActorsComponent, data: { reuse: true } },
   { path: 'about', component: AboutComponent },
   { path: 'logs', component: LogsComponent },

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -13,6 +13,7 @@ import { ReusableRouteStrategy } from './reusable-route.strategy';
 import { HeaderComponent } from './components/header/header.component';
 import { RecommendedComponent } from './components/recommended/recommended.component';
 import { ActorsComponent } from './components/actors/actors.component';
+import { SimilarComponent } from './components/similar/similar.component';
 import { AboutComponent } from './components/about/about.component';
 import { IndexComponent } from './index/index.component';
 import { PlexSettingsComponent } from './components/settings/plex-settings/plex-settings.component';
@@ -39,6 +40,7 @@ import { CompactNumberPipe } from './pipes/compact-number.pipe';
         ScanHistoryComponent,
         RecommendedComponent,
         ActorsComponent,
+        SimilarComponent,
         AboutComponent,
         IndexComponent,
         PlexSettingsComponent,

--- a/frontend/src/app/components/actors/actors.component.html
+++ b/frontend/src/app/components/actors/actors.component.html
@@ -1,3 +1,13 @@
+<app-confirm-modal
+  [visible]="pendingIgnoreGap !== null"
+  title="Ignore Item"
+  [message]="ignoreConfirmationMessage"
+  confirmText="Ignore"
+  type="warning"
+  (confirmed)="onIgnoreConfirm()"
+  (cancelled)="onIgnoreCancel()"
+></app-confirm-modal>
+
 <div class="container top-margin pb-5">
   <!-- Loading -->
   <div *ngIf="loading" class="text-center mt-4">

--- a/frontend/src/app/components/actors/actors.component.ts
+++ b/frontend/src/app/components/actors/actors.component.ts
@@ -73,6 +73,7 @@ export class ActorsComponent implements OnInit, OnDestroy {
   renderLimit = this.RENDER_CHUNK;
   private renderObserver?: IntersectionObserver;
   ignoredIds: Set<number> = new Set();
+  pendingIgnoreGap: Gap | null = null;
 
   // Primary owned/missing selector — the whole point of the page.
   view: 'all' | 'owned' | 'missing' = 'all';
@@ -554,11 +555,31 @@ export class ActorsComponent implements OnInit, OnDestroy {
     if (this.ignoredIds.has(gap.id)) {
       this.ignoredIds.delete(gap.id);
       this.ignoreRemove(gap.id).subscribe({ error: () => this.ignoredIds.add(gap.id) });
-    } else {
-      this.ignoredIds.add(gap.id);
-      this.ignoreAdd(gap.id).subscribe({ error: () => this.ignoredIds.delete(gap.id) });
+      this.applyFilter();
+      return;
     }
+
+    this.pendingIgnoreGap = gap;
+  }
+
+  get ignoreConfirmationMessage(): string {
+    return this.pendingIgnoreGap
+      ? `Are you sure you want to ignore "${this.pendingIgnoreGap.name}"?`
+      : '';
+  }
+
+  onIgnoreConfirm(): void {
+    const gap = this.pendingIgnoreGap;
+    this.pendingIgnoreGap = null;
+    if (!gap || this.ignoredIds.has(gap.id)) return;
+
+    this.ignoredIds.add(gap.id);
+    this.ignoreAdd(gap.id).subscribe({ error: () => this.ignoredIds.delete(gap.id) });
     this.applyFilter();
+  }
+
+  onIgnoreCancel(): void {
+    this.pendingIgnoreGap = null;
   }
 
   // Windowed rendering may hand a partial group to the template; resolve the

--- a/frontend/src/app/components/header/header.component.html
+++ b/frontend/src/app/components/header/header.component.html
@@ -24,6 +24,12 @@
                   </a>
               </li>
               <li class="nav-item nav-button-padding" routerLinkActive="active">
+                  <a class="nav-link center-text nav-anchor-spacing" [routerLink]="['/similar']">
+                      <img alt="" class="d-inline-block align-top" src="assets/images/heart-fill.svg" width="32" height="32">
+                      Similar
+                  </a>
+              </li>
+              <li class="nav-item nav-button-padding" routerLinkActive="active">
                   <a class="nav-link center-text nav-anchor-spacing" [routerLink]="['/settings']">
                       <img alt="" class="d-inline-block align-top" src="assets/images/gear.svg" width="32" height="32">
                       Settings

--- a/frontend/src/app/components/header/header.component.spec.ts
+++ b/frontend/src/app/components/header/header.component.spec.ts
@@ -21,13 +21,14 @@ describe('HeaderComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should render navigation links for Dashboard, Missing, Settings, Logs, and About', () => {
+  it('should render the primary navigation links', () => {
     const el = fixture.nativeElement as HTMLElement;
     const linkTexts = Array.from(el.querySelectorAll('a.nav-link'))
       .map(a => a.textContent?.trim());
 
     expect(linkTexts.some(t => t?.includes('Dashboard'))).toBeTrue();
     expect(linkTexts.some(t => t?.includes('Missing'))).toBeTrue();
+    expect(linkTexts.some(t => t?.includes('Similar'))).toBeTrue();
     expect(linkTexts.some(t => t?.includes('Settings'))).toBeTrue();
     expect(linkTexts.some(t => t?.includes('Logs'))).toBeTrue();
     expect(linkTexts.some(t => t?.includes('About'))).toBeTrue();

--- a/frontend/src/app/components/recommended/recommended.component.html
+++ b/frontend/src/app/components/recommended/recommended.component.html
@@ -10,6 +10,16 @@
   (cancelled)="onFreshScanCancel()"
 ></app-confirm-modal>
 
+<app-confirm-modal
+  [visible]="pendingIgnoreGap !== null"
+  title="Ignore Item"
+  [message]="ignoreConfirmationMessage"
+  confirmText="Ignore"
+  type="warning"
+  (confirmed)="onIgnoreConfirm()"
+  (cancelled)="onIgnoreCancel()"
+></app-confirm-modal>
+
 <div class="container top-margin pb-5">
   <!-- Movies / TV Shows toggle -->
   <div class="btn-group media-type-toggle mb-3" role="group">

--- a/frontend/src/app/components/recommended/recommended.component.spec.ts
+++ b/frontend/src/app/components/recommended/recommended.component.spec.ts
@@ -271,19 +271,51 @@ describe('RecommendedComponent', () => {
     expect(component.missingCount).toBe(1);
   });
 
-  it('toggleIgnore should add/remove from ignored set', () => {
+  it('toggleIgnore should request confirmation before ignoring an item', () => {
     const g = gap({ id: 42, name: 'Test', groupName: 'C', owned: false });
     component.allGaps = [g];
     component.ignoredIds = new Set();
     recommendationService.addIgnored.and.returnValue(of({}));
+
+    const event = new Event('click');
+    component.toggleIgnore(g, event);
+
+    expect(component.pendingIgnoreGap).toBe(g);
+    expect(component.ignoreConfirmationMessage).toContain('Test');
+    expect(component.ignoredIds.has(42)).toBeFalse();
+    expect(recommendationService.addIgnored).not.toHaveBeenCalled();
+
+    component.onIgnoreConfirm();
+
+    expect(component.pendingIgnoreGap).toBeNull();
+    expect(component.ignoredIds.has(42)).toBeTrue();
+    expect(recommendationService.addIgnored).toHaveBeenCalledWith(42);
+  });
+
+  it('onIgnoreCancel should leave the item unignored', () => {
+    const g = gap({ id: 42, name: 'Test', groupName: 'C', owned: false });
+    component.pendingIgnoreGap = g;
+    component.ignoredIds = new Set();
+
+    component.onIgnoreCancel();
+
+    expect(component.pendingIgnoreGap).toBeNull();
+    expect(component.ignoredIds.has(42)).toBeFalse();
+    expect(recommendationService.addIgnored).not.toHaveBeenCalled();
+  });
+
+  it('toggleIgnore should unignore an ignored item without confirmation', () => {
+    const g = gap({ id: 42, name: 'Test', groupName: 'C', owned: false });
+    component.allGaps = [g];
+    component.ignoredIds = new Set([42]);
     recommendationService.removeIgnored.and.returnValue(of({}));
 
     const event = new Event('click');
     component.toggleIgnore(g, event);
-    expect(component.ignoredIds.has(42)).toBeTrue();
 
-    component.toggleIgnore(g, event);
+    expect(component.pendingIgnoreGap).toBeNull();
     expect(component.ignoredIds.has(42)).toBeFalse();
+    expect(recommendationService.removeIgnored).toHaveBeenCalledWith(42);
   });
 
   it('toggleLibrarySelection should add/remove from selectedLibraries', () => {

--- a/frontend/src/app/components/recommended/recommended.component.ts
+++ b/frontend/src/app/components/recommended/recommended.component.ts
@@ -229,6 +229,7 @@ export class RecommendedComponent implements OnInit, OnDestroy {
   private renderObserver?: IntersectionObserver;
   // Ignored items (TMDB ids for movies, TheTVDB ids for shows — reloaded on toggle)
   ignoredIds: Set<number> = new Set();
+  pendingIgnoreGap: Gap | null = null;
   showIgnored = false;
   selectedItem: BrowseItem | null = null;
   scanMode = false;
@@ -1057,16 +1058,36 @@ export class RecommendedComponent implements OnInit, OnDestroy {
     return this.ignoredIds.has(gap.id);
   }
 
+  get ignoreConfirmationMessage(): string {
+    return this.pendingIgnoreGap
+      ? `Are you sure you want to ignore "${this.pendingIgnoreGap.name}"?`
+      : '';
+  }
+
   toggleIgnore(gap: Gap, event: Event): void {
     event.stopPropagation();
     if (this.ignoredIds.has(gap.id)) {
       this.ignoredIds.delete(gap.id);
       this.ignoreRemove(gap.id).subscribe({ error: () => this.ignoredIds.add(gap.id) });
-    } else {
-      this.ignoredIds.add(gap.id);
-      this.ignoreAdd(gap.id).subscribe({ error: () => this.ignoredIds.delete(gap.id) });
+      this.applyFilter();
+      return;
     }
+
+    this.pendingIgnoreGap = gap;
+  }
+
+  onIgnoreConfirm(): void {
+    const gap = this.pendingIgnoreGap;
+    this.pendingIgnoreGap = null;
+    if (!gap || this.ignoredIds.has(gap.id)) return;
+
+    this.ignoredIds.add(gap.id);
+    this.ignoreAdd(gap.id).subscribe({ error: () => this.ignoredIds.delete(gap.id) });
     this.applyFilter();
+  }
+
+  onIgnoreCancel(): void {
+    this.pendingIgnoreGap = null;
   }
 
   // The template renders windowed groups (progressive rendering), so the group

--- a/frontend/src/app/components/similar/similar.component.html
+++ b/frontend/src/app/components/similar/similar.component.html
@@ -1,0 +1,169 @@
+<div class="container top-margin pb-5">
+  <div *ngIf="loading" class="text-center mt-4">
+    <div class="spinner"></div>
+    <p class="text-muted mt-2">Loading...</p>
+  </div>
+
+  <div *ngIf="!loading && !hasServer" class="text-center mt-4">
+    <h4 class="text-muted">No Active Server</h4>
+    <p class="text-muted">
+      Configure a media server first.
+      <a [routerLink]="['/settings']" class="activeLink">Go to Settings</a>
+    </p>
+  </div>
+
+  <div *ngIf="!loading && hasServer">
+    <h3 class="regular-text">Similar If You Liked</h3>
+    <p class="text-muted">
+      Pick a movie you own and discover similar titles from TMDB. Results show what is already in your selected libraries.
+    </p>
+
+    <div *ngIf="libraries.length === 0" class="alert alert-info">
+      No movie libraries found on <strong>{{ activeServerName }}</strong>.
+    </div>
+
+    <div *ngIf="libraries.length > 0" class="pref-card mb-3">
+      <div class="d-flex align-items-center flex-wrap gap-2">
+        <span class="text-muted small me-1">Check ownership in:</span>
+        <div *ngFor="let library of libraries" class="form-check form-check-inline m-0">
+          <input
+            class="form-check-input"
+            type="checkbox"
+            [id]="'similar-lib-' + library.title"
+            [checked]="isLibrarySelected(library.title)"
+            (change)="toggleLibrarySelection(library.title)"
+          >
+          <label class="form-check-label text-muted small" [for]="'similar-lib-' + library.title">
+            {{ library.title }}
+          </label>
+        </div>
+      </div>
+    </div>
+
+    <div *ngIf="loadingMovies || loadingSimilar" class="text-center mt-4">
+      <div class="spinner"></div>
+      <p class="text-muted mt-2">{{ loadingSimilar ? 'Finding similar movies on TMDB...' : 'Loading your movies...' }}</p>
+    </div>
+
+    <div *ngIf="errorMessage" class="alert alert-danger mt-3">{{ errorMessage }}</div>
+
+    <div *ngIf="!loadingMovies && !loadingSimilar && selectedLibraries.length === 0" class="alert alert-info">
+      Select at least one movie library to continue.
+    </div>
+
+    <div *ngIf="!loadingMovies && !loadingSimilar && selectedLibraries.length > 0 && movies.length === 0" class="alert alert-info">
+      No movies with TMDB IDs were found in the selected libraries.
+    </div>
+
+    <div *ngIf="!loadingMovies && !loadingSimilar && movies.length > 0 && !selectedMovie">
+      <h5 class="regular-text">Choose a movie you liked</h5>
+      <input
+        class="form-control dark-input mb-3"
+        type="text"
+        placeholder="Filter your movies by name..."
+        [(ngModel)]="movieFilter"
+        (ngModelChange)="currentPage = 1"
+      >
+
+      <div class="seed-grid">
+        <button
+          *ngFor="let movie of pagedMovies; trackBy: trackByMovie"
+          type="button"
+          class="seed-card"
+          (click)="selectMovie(movie)">
+          <img *ngIf="movie.posterUrl" [src]="movie.posterUrl" [alt]="movie.name" loading="lazy">
+          <span *ngIf="!movie.posterUrl" class="seed-placeholder">No Image</span>
+          <span class="seed-info">
+            <span class="seed-title">{{ movie.name }}</span>
+            <span class="seed-year">{{ movie.year }}</span>
+          </span>
+        </button>
+      </div>
+
+      <div *ngIf="totalPages > 1" class="mt-3 d-flex align-items-center justify-content-center gap-3">
+        <button class="btn btn-sm btn-outline-light" [disabled]="currentPage === 1" (click)="onPageChange(-1)">
+          &larr; Prev
+        </button>
+        <span class="text-muted">Page {{ currentPage }} of {{ totalPages }}</span>
+        <button class="btn btn-sm btn-outline-light" [disabled]="currentPage === totalPages" (click)="onPageChange(1)">
+          Next &rarr;
+        </button>
+      </div>
+    </div>
+
+    <div *ngIf="!loadingSimilar && selectedMovie">
+      <div class="result-toolbar d-flex align-items-center gap-3 mb-3">
+        <button class="btn btn-sm btn-outline-light" (click)="clearResults()">&larr; Back</button>
+        <h5 class="regular-text mb-0">
+          Because you liked {{ selectedMovie.name }} ({{ selectedMovie.year }})
+        </h5>
+        <div class="btn-group btn-group-sm ms-auto" role="group" aria-label="Owned or missing">
+          <button type="button" class="btn"
+                  [class.btn-primary]="view === 'all'"
+                  [class.btn-outline-secondary]="view !== 'all'"
+                  (click)="setView('all')">All ({{ allSimilar.length }})</button>
+          <button type="button" class="btn"
+                  [class.btn-primary]="view === 'owned'"
+                  [class.btn-outline-secondary]="view !== 'owned'"
+                  (click)="setView('owned')">Owned ({{ ownedCount }})</button>
+          <button type="button" class="btn"
+                  [class.btn-primary]="view === 'missing'"
+                  [class.btn-outline-secondary]="view !== 'missing'"
+                  (click)="setView('missing')">Missing ({{ missingCount }})</button>
+        </div>
+      </div>
+
+      <div class="result-controls d-flex gap-2 mb-3">
+        <input
+          class="form-control dark-input"
+          type="text"
+          placeholder="Filter similar movies..."
+          [(ngModel)]="resultFilter"
+          (ngModelChange)="applyFilter()"
+        >
+        <select class="form-select dark-select result-sort" [(ngModel)]="sortBy" (ngModelChange)="applyFilter()">
+          <option value="relevance">TMDB relevance</option>
+          <option value="rating">Rating</option>
+          <option value="year">Year (newest)</option>
+          <option value="name">Title (A-Z)</option>
+        </select>
+      </div>
+
+      <div *ngIf="filteredSimilar.length > 0" class="rec-grid">
+        <article *ngFor="let movie of filteredSimilar; trackBy: trackByGap" class="rec-card" [class.owned]="movie.owned">
+          <div class="owned-badge" *ngIf="movie.owned">Owned</div>
+          <div class="missing-badge" *ngIf="!movie.owned">Missing</div>
+          <a [href]="movie.externalUrl" target="_blank" rel="noopener noreferrer">
+            <img *ngIf="movie.posterUrl" [src]="movie.posterUrl" [alt]="movie.name" class="rec-poster" loading="lazy">
+            <div *ngIf="!movie.posterUrl" class="rec-poster-placeholder">No Image</div>
+          </a>
+          <div class="rec-info">
+            <a [href]="movie.externalUrl" target="_blank" rel="noopener noreferrer" class="rec-title-link">
+              {{ movie.name }}
+            </a>
+            <div class="rec-year">{{ movie.year }}</div>
+            <div class="card-ratings" *ngIf="movie.tmdbRating">
+              <span class="rating-chip tmdb" [title]="(movie.tmdbVotes | number) + ' votes on TMDB'">
+                <img class="rating-logo" src="assets/images/tmdb-logo.svg" alt="TMDB">
+                {{ movie.tmdbRating | number:'1.1-1' }}
+              </span>
+            </div>
+            <button
+              *ngIf="canSendToRadarr(movie)"
+              class="btn btn-sm radarr-btn"
+              [ngClass]="radarrButtonClass(movie.id)"
+              [disabled]="radarrStatus(movie.id) === 'sending' || radarrStatus(movie.id) === 'sent'"
+              [title]="radarrError(movie.id) || 'Add this movie to Radarr'"
+              (click)="sendToRadarr(movie, $event)">
+              {{ radarrLabel(movie.id) }}
+            </button>
+          </div>
+        </article>
+      </div>
+
+      <p *ngIf="filteredSimilar.length === 0 && !errorMessage" class="text-muted">
+        {{ allSimilar.length === 0 ? 'TMDB did not return any similar movies for this title.' : 'No movies match the current filters.' }}
+      </p>
+    </div>
+  </div>
+</div>

--- a/frontend/src/app/components/similar/similar.component.scss
+++ b/frontend/src/app/components/similar/similar.component.scss
@@ -1,0 +1,84 @@
+/* Result cards, badges, inputs, and Radarr buttons are shared in src/styles.scss. */
+
+.seed-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  gap: 12px;
+}
+
+.seed-card {
+  padding: 0;
+  overflow: hidden;
+  color: inherit;
+  text-align: left;
+  background: #2d2d2d;
+  border: 1px solid #444;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: border-color 0.2s, transform 0.2s;
+
+  &:hover,
+  &:focus {
+    border-color: #00bc8c;
+    transform: translateY(-2px);
+  }
+
+  img {
+    display: block;
+    width: 100%;
+    height: auto;
+  }
+}
+
+.seed-placeholder {
+  display: flex;
+  height: 180px;
+  align-items: center;
+  justify-content: center;
+  color: #666;
+  background: #1a1a1a;
+}
+
+.seed-info {
+  display: block;
+  padding: 8px;
+}
+
+.seed-title,
+.seed-year {
+  display: block;
+}
+
+.seed-title {
+  overflow: hidden;
+  color: #fff;
+  font-size: 13px;
+  font-weight: 500;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.seed-year {
+  color: #999;
+  font-size: 12px;
+}
+
+.result-sort {
+  width: 190px;
+}
+
+@media (max-width: 767px) {
+  .result-toolbar,
+  .result-controls {
+    align-items: stretch !important;
+    flex-direction: column;
+  }
+
+  .result-toolbar .btn-group {
+    margin-left: 0 !important;
+  }
+
+  .result-sort {
+    width: 100%;
+  }
+}

--- a/frontend/src/app/components/similar/similar.component.spec.ts
+++ b/frontend/src/app/components/similar/similar.component.spec.ts
@@ -1,0 +1,109 @@
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { FormsModule } from '@angular/forms';
+import { RouterTestingModule } from '@angular/router/testing';
+import { of } from 'rxjs';
+import { SimilarComponent } from './similar.component';
+import { ActiveServerService, ActiveServer } from '../../services/active-server.service';
+import { LibraryService } from '../../services/library.service';
+import { PreferencesService, DEFAULT_PREFERENCES } from '../../services/preferences.service';
+import { RecommendationService } from '../../services/recommendation.service';
+import { RadarrService } from '../../services/radarr.service';
+import { Movie } from '../../models/movie.model';
+
+describe('SimilarComponent', () => {
+  let component: SimilarComponent;
+  let fixture: ComponentFixture<SimilarComponent>;
+  let libraryService: jasmine.SpyObj<LibraryService>;
+  let recommendationService: jasmine.SpyObj<RecommendationService>;
+
+  const seed: Movie = {
+    name: 'Alien',
+    year: 1979,
+    overview: '',
+    posterUrl: '',
+    tmdbId: 348,
+  };
+
+  beforeEach(async () => {
+    const activeServerService = jasmine.createSpyObj<ActiveServerService>('ActiveServerService', ['getActive']);
+    libraryService = jasmine.createSpyObj<LibraryService>('LibraryService', ['getMovies']);
+    const preferencesService = jasmine.createSpyObj<PreferencesService>('PreferencesService', ['load']);
+    recommendationService = jasmine.createSpyObj<RecommendationService>('RecommendationService', ['getSimilarMovies']);
+    const radarrService = jasmine.createSpyObj<RadarrService>(
+      'RadarrService',
+      ['getConfig', 'getLibraryTmdbIds', 'addMovie'],
+    );
+
+    const active: ActiveServer = {
+      source: 'plex',
+      typeLabel: 'Plex',
+      server: 'Test Plex',
+      libraries: [{ title: 'Movies', type: 'movie' }],
+      response: {
+        server: 'Test Plex',
+        token: '',
+        libraries: [{ title: 'Movies', type: 'movie' }],
+      },
+    };
+    activeServerService.getActive.and.returnValue(of(active));
+    preferencesService.load.and.returnValue(of({ ...DEFAULT_PREFERENCES, defaultLibrary: 'Movies' }));
+    libraryService.getMovies.and.returnValue(of({ movies: [seed] }));
+    radarrService.getConfig.and.returnValue(of({ enabled: false } as any));
+    recommendationService.getSimilarMovies.and.returnValue(of([]));
+
+    await TestBed.configureTestingModule({
+      imports: [FormsModule, RouterTestingModule],
+      declarations: [SimilarComponent],
+      providers: [
+        { provide: ActiveServerService, useValue: activeServerService },
+        { provide: LibraryService, useValue: libraryService },
+        { provide: PreferencesService, useValue: preferencesService },
+        { provide: RecommendationService, useValue: recommendationService },
+        { provide: RadarrService, useValue: radarrService },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(SimilarComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('loads TMDB-backed movies from the default movie library', fakeAsync(() => {
+    fixture.detectChanges();
+    tick();
+
+    expect(component.selectedLibraries).toEqual(['Movies']);
+    expect(libraryService.getMovies).toHaveBeenCalledWith('Movies', 'plex');
+    expect(component.movies).toEqual([seed]);
+  }));
+
+  it('uses the selected movie TMDB ID and marks owned and missing results', fakeAsync(() => {
+    recommendationService.getSimilarMovies.and.returnValue(of([
+      {
+        tmdbId: 1, name: 'Owned', year: '2000', posterUrl: null,
+        overview: '', collectionName: 'Similar Movies', owned: true,
+      },
+      {
+        tmdbId: 2, name: 'Missing', year: '2001', posterUrl: null,
+        overview: '', collectionName: 'Similar Movies', owned: false,
+      },
+    ]));
+    component.selectedLibraries = ['Movies'];
+
+    component.selectMovie(seed);
+    tick();
+
+    expect(recommendationService.getSimilarMovies).toHaveBeenCalledWith(348, ['Movies'], 'plex');
+    expect(component.ownedCount).toBe(1);
+    expect(component.missingCount).toBe(1);
+
+    component.setView('missing');
+    expect(component.filteredSimilar.map(movie => movie.name)).toEqual(['Missing']);
+  }));
+
+  it('does not query TMDB when the selected movie has no TMDB ID', () => {
+    component.selectMovie({ ...seed, name: 'Unknown', tmdbId: undefined });
+
+    expect(recommendationService.getSimilarMovies).not.toHaveBeenCalled();
+    expect(component.errorMessage).toContain('no TMDB ID');
+  });
+});

--- a/frontend/src/app/components/similar/similar.component.ts
+++ b/frontend/src/app/components/similar/similar.component.ts
@@ -1,0 +1,308 @@
+import { Component, OnInit } from '@angular/core';
+import { forkJoin, of } from 'rxjs';
+import { catchError, map } from 'rxjs/operators';
+import { ActiveServerService, MediaServerSource } from '../../services/active-server.service';
+import { LibraryService } from '../../services/library.service';
+import { PreferencesService } from '../../services/preferences.service';
+import { RecommendationService } from '../../services/recommendation.service';
+import { RadarrService } from '../../services/radarr.service';
+import { MediaLibrary } from '../../models/media-server.model';
+import { Movie } from '../../models/movie.model';
+import { Gap } from '../../models/recommendation.model';
+
+type ResultView = 'all' | 'owned' | 'missing';
+type ResultSort = 'relevance' | 'rating' | 'year' | 'name';
+type SendState = 'sending' | 'sent' | 'error';
+
+@Component({
+  selector: 'app-similar',
+  templateUrl: './similar.component.html',
+  styleUrls: ['./similar.component.scss'],
+  standalone: false,
+})
+export class SimilarComponent implements OnInit {
+  loading = true;
+  loadingMovies = false;
+  loadingSimilar = false;
+  hasServer = false;
+  activeSource: MediaServerSource = 'plex';
+  activeServerName = '';
+
+  libraries: MediaLibrary[] = [];
+  selectedLibraries: string[] = [];
+  movies: Movie[] = [];
+  selectedMovie: Movie | null = null;
+  movieFilter = '';
+  currentPage = 1;
+  itemsPerPage = 50;
+
+  allSimilar: Gap[] = [];
+  filteredSimilar: Gap[] = [];
+  resultFilter = '';
+  view: ResultView = 'all';
+  sortBy: ResultSort = 'relevance';
+  ownedCount = 0;
+  missingCount = 0;
+  errorMessage = '';
+
+  radarrEnabled = false;
+  private sendStatus = new Map<number, SendState>();
+  private sendErrors = new Map<number, string>();
+
+  constructor(
+    private activeServerService: ActiveServerService,
+    private libraryService: LibraryService,
+    private preferencesService: PreferencesService,
+    private recommendationService: RecommendationService,
+    private radarrService: RadarrService,
+  ) {}
+
+  ngOnInit(): void {
+    this.refreshRadarrStatus();
+    forkJoin({
+      active: this.activeServerService.getActive(),
+      prefs: this.preferencesService.load().pipe(catchError(() => of(null))),
+    }).subscribe(({ active, prefs }) => {
+      if (!active) {
+        this.loading = false;
+        return;
+      }
+
+      this.hasServer = true;
+      this.activeSource = active.source;
+      this.activeServerName = active.server;
+      this.libraries = active.libraries.filter(lib => lib.type === 'movie');
+      this.itemsPerPage = prefs?.moviesPerPage || 50;
+
+      if (this.libraries.length) {
+        const preferred = prefs?.defaultLibrary;
+        const initial = preferred && this.libraries.some(lib => lib.title === preferred)
+          ? preferred
+          : this.libraries[0].title;
+        this.selectedLibraries = [initial];
+        this.loadMovies();
+      }
+      this.loading = false;
+    });
+  }
+
+  get filteredMovies(): Movie[] {
+    const query = this.movieFilter.trim().toLowerCase();
+    return query
+      ? this.movies.filter(movie => movie.name.toLowerCase().includes(query))
+      : this.movies;
+  }
+
+  get pagedMovies(): Movie[] {
+    const start = (this.currentPage - 1) * this.itemsPerPage;
+    return this.filteredMovies.slice(start, start + this.itemsPerPage);
+  }
+
+  get totalPages(): number {
+    return Math.max(1, Math.ceil(this.filteredMovies.length / this.itemsPerPage));
+  }
+
+  toggleLibrarySelection(title: string): void {
+    const index = this.selectedLibraries.indexOf(title);
+    if (index >= 0) {
+      this.selectedLibraries.splice(index, 1);
+    } else {
+      this.selectedLibraries.push(title);
+    }
+    this.loadMovies();
+  }
+
+  isLibrarySelected(title: string): boolean {
+    return this.selectedLibraries.includes(title);
+  }
+
+  loadMovies(): void {
+    this.movies = [];
+    this.selectedMovie = null;
+    this.allSimilar = [];
+    this.filteredSimilar = [];
+    this.movieFilter = '';
+    this.currentPage = 1;
+    this.errorMessage = '';
+
+    if (!this.selectedLibraries.length) {
+      this.loadingMovies = false;
+      return;
+    }
+
+    this.loadingMovies = true;
+    forkJoin(
+      this.selectedLibraries.map(title =>
+        this.libraryService.getMovies(title, this.activeSource)
+          .pipe(catchError(() => of({ movies: [] as Movie[] })))
+      )
+    ).subscribe(results => {
+      const seen = new Set<number>();
+      const merged: Movie[] = [];
+      for (const result of results) {
+        for (const movie of result.movies || []) {
+          if (!movie.tmdbId || seen.has(movie.tmdbId)) continue;
+          seen.add(movie.tmdbId);
+          merged.push(movie);
+        }
+      }
+      this.movies = merged.sort((a, b) => a.name.localeCompare(b.name));
+      this.loadingMovies = false;
+    });
+  }
+
+  selectMovie(movie: Movie): void {
+    if (!movie.tmdbId) {
+      this.errorMessage = '"' + movie.name + '" has no TMDB ID and cannot be used for a similar-movie lookup.';
+      return;
+    }
+
+    this.selectedMovie = movie;
+    this.loadingSimilar = true;
+    this.allSimilar = [];
+    this.filteredSimilar = [];
+    this.resultFilter = '';
+    this.errorMessage = '';
+
+    this.recommendationService.getSimilarMovies(
+      movie.tmdbId,
+      this.selectedLibraries,
+      this.activeSource,
+    ).subscribe({
+      next: rows => {
+        this.allSimilar = (rows || []).map(row => ({
+          id: row.tmdbId,
+          tmdbId: row.tmdbId,
+          name: row.name,
+          year: row.year,
+          releaseDate: row.releaseDate,
+          posterUrl: row.posterUrl ?? null,
+          overview: row.overview || '',
+          groupName: 'Similar Movies',
+          owned: !!row.owned,
+          externalUrl: 'https://www.themoviedb.org/movie/' + row.tmdbId,
+          radarrEligible: !!row.tmdbId,
+          sonarrEligible: false,
+          tmdbRating: row.voteAverage && row.voteAverage > 0 ? row.voteAverage : undefined,
+          tmdbVotes: row.voteCount || undefined,
+          genreIds: row.genreIds || [],
+          popularity: row.popularity || 0,
+        }));
+        this.applyFilter();
+        this.loadingSimilar = false;
+      },
+      error: err => {
+        this.errorMessage = err.error?.error || 'Failed to load similar movies from TMDB.';
+        this.loadingSimilar = false;
+      },
+    });
+  }
+
+  clearResults(): void {
+    this.selectedMovie = null;
+    this.allSimilar = [];
+    this.filteredSimilar = [];
+    this.resultFilter = '';
+    this.errorMessage = '';
+  }
+
+  setView(view: ResultView): void {
+    this.view = view;
+    this.applyFilter();
+  }
+
+  applyFilter(): void {
+    this.ownedCount = this.allSimilar.filter(movie => movie.owned).length;
+    this.missingCount = this.allSimilar.length - this.ownedCount;
+
+    let rows = [...this.allSimilar];
+    if (this.view === 'owned') rows = rows.filter(movie => movie.owned);
+    if (this.view === 'missing') rows = rows.filter(movie => !movie.owned);
+
+    const query = this.resultFilter.trim().toLowerCase();
+    if (query) rows = rows.filter(movie => movie.name.toLowerCase().includes(query));
+
+    if (this.sortBy === 'rating') {
+      rows.sort((a, b) => (b.tmdbRating || 0) - (a.tmdbRating || 0));
+    } else if (this.sortBy === 'year') {
+      rows.sort((a, b) => String(b.year).localeCompare(String(a.year)));
+    } else if (this.sortBy === 'name') {
+      rows.sort((a, b) => a.name.localeCompare(b.name));
+    }
+    this.filteredSimilar = rows;
+  }
+
+  onPageChange(delta: number): void {
+    this.currentPage = Math.min(this.totalPages, Math.max(1, this.currentPage + delta));
+  }
+
+  trackByMovie(_index: number, movie: Movie): number {
+    return movie.tmdbId || 0;
+  }
+
+  trackByGap(_index: number, gap: Gap): number {
+    return gap.id;
+  }
+
+  private refreshRadarrStatus(): void {
+    this.radarrService.getConfig().pipe(catchError(() => of(null))).subscribe(config => {
+      this.radarrEnabled = !!config?.enabled;
+      if (!this.radarrEnabled) return;
+      this.radarrService.getLibraryTmdbIds().pipe(
+        map(response => response.tmdb_ids || []),
+        catchError(() => of([] as number[])),
+      ).subscribe(ids => {
+        for (const id of ids) this.sendStatus.set(id, 'sent');
+      });
+    });
+  }
+
+  canSendToRadarr(movie: Gap): boolean {
+    return this.radarrEnabled && movie.radarrEligible && !movie.owned;
+  }
+
+  sendToRadarr(movie: Gap, event: Event): void {
+    event.stopPropagation();
+    event.preventDefault();
+    if (!this.canSendToRadarr(movie) || this.sendStatus.get(movie.id) === 'sending') return;
+
+    this.sendStatus.set(movie.id, 'sending');
+    this.sendErrors.delete(movie.id);
+    this.radarrService.addMovie(
+      movie.id,
+      movie.name,
+      parseInt(String(movie.year), 10) || 0,
+    ).subscribe({
+      next: () => this.sendStatus.set(movie.id, 'sent'),
+      error: err => {
+        this.sendStatus.set(movie.id, 'error');
+        this.sendErrors.set(movie.id, err.error?.error || 'Failed to add to Radarr');
+      },
+    });
+  }
+
+  radarrStatus(id: number): SendState | undefined {
+    return this.sendStatus.get(id);
+  }
+
+  radarrError(id: number): string | undefined {
+    return this.sendErrors.get(id);
+  }
+
+  radarrLabel(id: number): string {
+    switch (this.radarrStatus(id)) {
+      case 'sending': return 'Sending...';
+      case 'sent': return 'In Radarr';
+      case 'error': return 'Retry';
+      default: return 'Send to Radarr';
+    }
+  }
+
+  radarrButtonClass(id: number): string {
+    switch (this.radarrStatus(id)) {
+      case 'sent': return 'btn-success';
+      case 'error': return 'btn-outline-danger';
+      default: return 'btn-outline-primary';
+    }
+  }
+}

--- a/frontend/src/app/models/recommendation.model.ts
+++ b/frontend/src/app/models/recommendation.model.ts
@@ -7,6 +7,10 @@ export interface CollectionGap {
   overview: string;
   collectionName: string;
   owned: boolean;
+  voteAverage?: number;
+  voteCount?: number;
+  genreIds?: number[];
+  popularity?: number;
 }
 
 /**

--- a/frontend/src/app/services/recommendation.service.ts
+++ b/frontend/src/app/services/recommendation.service.ts
@@ -61,6 +61,23 @@ export class RecommendationService {
     ).pipe(map(res => res.gaps));
   }
 
+  getSimilarMovies(
+    tmdbId: number,
+    libraryNames: string[],
+    source: string = 'plex'
+  ): Observable<CollectionGap[]> {
+    let params = new HttpParams()
+      .set('movieId', tmdbId.toString())
+      .set('source', source);
+    for (const libraryName of libraryNames) {
+      params = params.append('libraryNames', libraryName);
+    }
+    return this.http.get<{ gaps: CollectionGap[] }>(
+      environment.apiUrl + '/recommendations/similar',
+      { params }
+    ).pipe(map(res => res.gaps));
+  }
+
   startScan(
     libraryNames: string[],
     showExisting: boolean,

--- a/frontend/src/assets/images/heart-fill.svg
+++ b/frontend/src/assets/images/heart-fill.svg
@@ -1,0 +1,3 @@
+<svg class="bi bi-heart-fill" width="1em" height="1em" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+  <path fill="white" d="M8 14s6-3.33 6-8.1C14 3.22 12.1 2 10.4 2 9.28 2 8.48 2.58 8 3.28 7.52 2.58 6.72 2 5.6 2 3.9 2 2 3.22 2 5.9 2 10.67 8 14 8 14 8 14Z"/>
+</svg>

--- a/frontend/src/environments/environment.prod.ts
+++ b/frontend/src/environments/environment.prod.ts
@@ -1,5 +1,5 @@
 export const environment = {
   production: true,
   apiUrl: '/api',
-  version: '2.9.1'
+  version: '2.10.0'
 };

--- a/frontend/src/environments/environment.ts
+++ b/frontend/src/environments/environment.ts
@@ -1,5 +1,5 @@
 export const environment = {
   production: false,
   apiUrl: '/api',
-  version: '2.9.1'
+  version: '2.10.0'
 };


### PR DESCRIPTION
This pull request introduces a new "Similar Movies" feature that lets users discover movies related to those they already own, with clear owned/missing status. It also improves the UX for ignoring recommendations by adding confirmation modals in both the Recommended and Actors sections, and updates navigation to include the new feature. The backend is extended to support the similar-movies API, and the frontend is updated to route and display the new section.

**New "Similar Movies" feature:**
* Backend: Adds a `/similar` endpoint in `recommendations.py` that returns TMDB-similar movies for a given owned movie, annotated with ownership status.
* Backend: Implements `find_similar_movies` in `tmdb_service.py` to fetch and process similar movies from TMDB, marking owned/missing using TMDB IDs and title/year matching.
* Frontend: Adds `SimilarComponent`, updates routes in `app-routing.module.ts` and `app.module.ts`, and adds a "Similar" link to the main navigation and header. [[1]](diffhunk://#diff-166bf0ba59778a204139908879b1765cdefa6d588533ef7395fa41ca144aadadR6) [[2]](diffhunk://#diff-166bf0ba59778a204139908879b1765cdefa6d588533ef7395fa41ca144aadadR29) [[3]](diffhunk://#diff-a310791f1af78ce3436939d92bf03f7fff3c15bdc760f50afd68a1f5758ed2a7R16) [[4]](diffhunk://#diff-a310791f1af78ce3436939d92bf03f7fff3c15bdc760f50afd68a1f5758ed2a7R43) [[5]](diffhunk://#diff-a5e9c083f0620b16b3f5a475fbf959e95b368bfbc5457e80cf5f59eb3af1a1e8R26-R31)
* Documentation: Updates `README.md` to mention the new similar-movies discovery feature.

**Improved recommendation ignoring UX:**
* Adds confirmation modals when ignoring items in both Recommended and Actors sections, requiring user confirmation before marking items as ignored. [[1]](diffhunk://#diff-fc77d931f5bb3d05e97da5ea347365c7c84b909150a988cd87f780132e63e32bR13-R22) [[2]](diffhunk://#diff-dde41d24bf197d102ad17dfcf5de9ff670efba42c66ca03a5add68104bd2242dR1-R10) [[3]](diffhunk://#diff-8c075bf272c75aa7c4b4b82f0dfb2eec82aa3204bc5058bbc291f1155f3f0a04R232) [[4]](diffhunk://#diff-8c075bf272c75aa7c4b4b82f0dfb2eec82aa3204bc5058bbc291f1155f3f0a04R1061-R1092) [[5]](diffhunk://#diff-a09aa9469f9fd9ee54e9328b00def375b87331a41f5dacac0e7649cf919941f8R76) [[6]](diffhunk://#diff-a09aa9469f9fd9ee54e9328b00def375b87331a41f5dacac0e7649cf919941f8L557-R584)
* Updates tests for the new confirmation flow and ensures correct behavior for ignoring/unignoring items.

**Navigation and versioning updates:**
* Adds the "Similar" section to the main navigation and updates header tests accordingly. [[1]](diffhunk://#diff-a5e9c083f0620b16b3f5a475fbf959e95b368bfbc5457e80cf5f59eb3af1a1e8R26-R31) [[2]](diffhunk://#diff-096d94fef639b56e50a4d6c509eb10a86efa236a396ebcffa804d0e5cee08dcfL24-R31)
* Bumps backend version to `2.10.0` to reflect the new feature.